### PR TITLE
hotfix(button): rename custom event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Todas as mudanças notáveis deste projeto serão documentadas neste arquivo.
 
 Este projeto segue o [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/) e [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [1.5.2] – 2025-07-15
+
+### ✅ Corrigido
+
+- **Nome do evento click no componente YooButton**: O evento decorado com `@Event()` foi renomeado de `onClick` para `buttonClick` para evitar conflitos com o evento nativo do DOM `click`/`onClick`. Essa mudança elimina o aviso de build e garante que o evento personalizado seja emitido corretamente sem interferir nos eventos nativos.
+
 ## [1.5.1] – 2025-07-14
 
 ### 🚀 Adicionado

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yooga-tecnologia/mantra",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Biblioteca de componentes web desenvolvida com StencilJS para criar interfaces reutilizáveis e performáticas em diferentes frameworks e projetos.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,9 +8,11 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { ButtonProps } from "./components/yoo-button/yoo-button.types";
 import { IconProps } from "./components/yoo-icon/yoo-icon.types";
 import { IllustrationProps } from "./components/yoo-illustration/yoo-illustration.types";
+import { TooltipProps } from "./components/yoo-tooltip/yoo-tooltip.types";
 export { ButtonProps } from "./components/yoo-button/yoo-button.types";
 export { IconProps } from "./components/yoo-icon/yoo-icon.types";
 export { IllustrationProps } from "./components/yoo-illustration/yoo-illustration.types";
+export { TooltipProps } from "./components/yoo-tooltip/yoo-tooltip.types";
 export namespace Components {
     interface YooButton {
         "color": ButtonProps['color'];
@@ -43,6 +45,10 @@ export namespace Components {
         "placeholder"?: string;
         "trailingIcon": boolean;
     }
+    interface YooTooltip {
+        "position": TooltipProps['position'];
+        "text": TooltipProps['text'];
+    }
 }
 export interface YooButtonCustomEvent<T> extends CustomEvent<T> {
     detail: T;
@@ -50,7 +56,7 @@ export interface YooButtonCustomEvent<T> extends CustomEvent<T> {
 }
 declare global {
     interface HTMLYooButtonElementEventMap {
-        "onClick": MouseEvent;
+        "buttonClick": MouseEvent;
     }
     interface HTMLYooButtonElement extends Components.YooButton, HTMLStencilElement {
         addEventListener<K extends keyof HTMLYooButtonElementEventMap>(type: K, listener: (this: HTMLYooButtonElement, ev: YooButtonCustomEvent<HTMLYooButtonElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -84,11 +90,18 @@ declare global {
         prototype: HTMLYooInputGroupElement;
         new (): HTMLYooInputGroupElement;
     };
+    interface HTMLYooTooltipElement extends Components.YooTooltip, HTMLStencilElement {
+    }
+    var HTMLYooTooltipElement: {
+        prototype: HTMLYooTooltipElement;
+        new (): HTMLYooTooltipElement;
+    };
     interface HTMLElementTagNameMap {
         "yoo-button": HTMLYooButtonElement;
         "yoo-icon": HTMLYooIconElement;
         "yoo-illustration": HTMLYooIllustrationElement;
         "yoo-input-group": HTMLYooInputGroupElement;
+        "yoo-tooltip": HTMLYooTooltipElement;
     }
 }
 declare namespace LocalJSX {
@@ -100,7 +113,7 @@ declare namespace LocalJSX {
         "iconLeft"?: ButtonProps['iconLeft'];
         "iconRight"?: ButtonProps['iconRight'];
         "label"?: ButtonProps['label'];
-        "onOnClick"?: (event: YooButtonCustomEvent<MouseEvent>) => void;
+        "onButtonClick"?: (event: YooButtonCustomEvent<MouseEvent>) => void;
         "size"?: ButtonProps['size'];
         "variant"?: ButtonProps['variant'];
     }
@@ -124,11 +137,16 @@ declare namespace LocalJSX {
         "placeholder"?: string;
         "trailingIcon"?: boolean;
     }
+    interface YooTooltip {
+        "position"?: TooltipProps['position'];
+        "text"?: TooltipProps['text'];
+    }
     interface IntrinsicElements {
         "yoo-button": YooButton;
         "yoo-icon": YooIcon;
         "yoo-illustration": YooIllustration;
         "yoo-input-group": YooInputGroup;
+        "yoo-tooltip": YooTooltip;
     }
 }
 export { LocalJSX as JSX };
@@ -139,6 +157,7 @@ declare module "@stencil/core" {
             "yoo-icon": LocalJSX.YooIcon & JSXBase.HTMLAttributes<HTMLYooIconElement>;
             "yoo-illustration": LocalJSX.YooIllustration & JSXBase.HTMLAttributes<HTMLYooIllustrationElement>;
             "yoo-input-group": LocalJSX.YooInputGroup & JSXBase.HTMLAttributes<HTMLYooInputGroupElement>;
+            "yoo-tooltip": LocalJSX.YooTooltip & JSXBase.HTMLAttributes<HTMLYooTooltipElement>;
         }
     }
 }

--- a/src/components/yoo-button/yoo-button.spec.tsx
+++ b/src/components/yoo-button/yoo-button.spec.tsx
@@ -110,13 +110,12 @@ describe('<yoo-button>', () => {
 
   describe('Events', () => {
     it('SHOULD emit click event WHEN button is clicked', async () => {
-      const spy = jest.fn();
-
       // SETUP
       const page = await createButtonComponent(`<yoo-button label="${DEFAULT_LABEL}"></yoo-button>`);
       const button = getButtonElement(page);
       
-      page.root.addEventListener('onClick', spy);
+      const spy = jest.fn();
+      page.root.addEventListener('buttonClick', spy);
 
       // ACTION
       button.click();
@@ -131,7 +130,7 @@ describe('<yoo-button>', () => {
       const button = getButtonElement(page);
 
       const spy = jest.fn();
-      page.root.addEventListener('onClick', spy);
+      page.root.addEventListener('buttonClick', spy);
 
       // ACTION
       button.click();

--- a/src/components/yoo-button/yoo-button.tsx
+++ b/src/components/yoo-button/yoo-button.tsx
@@ -23,7 +23,7 @@ export class YooButton {
   @Prop() disabled: ButtonProps['disabled'] = false;
 
   // Events
-  @Event() onClick: EventEmitter<MouseEvent>;
+  @Event() buttonClick: EventEmitter<MouseEvent>;
 
   // Methods
   private handleClick(event: MouseEvent) {
@@ -33,7 +33,7 @@ export class YooButton {
       return;
     }
 
-    this.onClick.emit(event);
+    this.buttonClick.emit(event);
   }
 
   get buttonClass() {


### PR DESCRIPTION

### ✅ Corrigido

- **Nome do evento click no componente YooButton**: O evento decorado com `@Event()` foi renomeado de `onClick` para `buttonClick` para evitar conflitos com o evento nativo do DOM `click`/`onClick`. Essa mudança elimina o aviso de build e garante que o evento personalizado seja emitido corretamente sem interferir nos eventos nativos.