### PR TITLE
feat(tab): add tab navigation system 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,8 @@
     "icon",
     "brand",
     "field-number",
-    "button"
+    "button",
+    "tab"
   ],
   // Opcional: desabilite o auto-run se preferir rodar só manualmente
   // "jest.autoRun": false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ Todas as mudanças notáveis deste projeto serão documentadas neste arquivo.
 
 Este projeto segue o [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/) e [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [2.7.0] – 2025-01-15
+
+### 🚀 Adicionado
+
+- **Tab**: Sistema de navegação por abas com componentes mnt-tab-item e mnt-tab-item-group
+  - Suporte a orientação horizontal e vertical
+  - Ícones opcionais em cada tab
+  - Gerenciamento de estado de seleção (controlado ou automático)
+  - Eventos de mudança de tab (tabChange)
+  - Estados visuais: default, hover, selected, disabled
+
+### 📖 Documentação
+
+- **Tab**: Criação de documentação completa no Storybook
+  - Exemplos interativos com diferentes orientações
+  - Demonstração de tabs com e sem ícones
+  - Casos de uso com estados disabled
+
 ## [2.6.0] – 2025-01-15
 
 ### 🚀 Adicionado

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yooga-tecnologia/mantra",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Biblioteca de componentes web desenvolvida com StencilJS para criar interfaces reutilizáveis e performáticas em diferentes frameworks e projetos.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -13,6 +13,8 @@ import { FieldTextProps } from "./components/field-text/field-text.types";
 import { IconLargeProps, IconProps } from "./components/icon/icon.types";
 import { IllustrationProps } from "./components/illustration/illustration.types";
 import { StepItem, StepsProps, StepStatus } from "./components/steps/steps.types";
+import { TabItemProps } from "./components/tab-item/tab-item.types";
+import { TabItem, TabItemGroupProps } from "./components/tab-item-group/tab-item-group.types";
 import { TooltipProps } from "./components/tooltip/tooltip.types";
 export { BadgeBaseProps } from "./components/badge/badge.types";
 export { BrandProps } from "./components/brand/brand.types";
@@ -22,6 +24,8 @@ export { FieldTextProps } from "./components/field-text/field-text.types";
 export { IconLargeProps, IconProps } from "./components/icon/icon.types";
 export { IllustrationProps } from "./components/illustration/illustration.types";
 export { StepItem, StepsProps, StepStatus } from "./components/steps/steps.types";
+export { TabItemProps } from "./components/tab-item/tab-item.types";
+export { TabItem, TabItemGroupProps } from "./components/tab-item-group/tab-item-group.types";
 export { TooltipProps } from "./components/tooltip/tooltip.types";
 export namespace Components {
     interface MntBadge {
@@ -107,6 +111,19 @@ export namespace Components {
         "orientation": StepsProps['orientation'];
         "steps": StepsProps['steps'];
     }
+    interface MntTabItem {
+        "disabled": boolean;
+        "icon"?: TabItemProps['icon'];
+        "label": string;
+        "orientation": TabItemProps['orientation'];
+        "selected": boolean;
+        "tabId": string;
+    }
+    interface MntTabItemGroup {
+        "orientation": TabItemGroupProps['orientation'];
+        "selectedId"?: string;
+        "tabs": TabItem[] | string;
+    }
     interface MntTooltip {
         "position": TooltipProps['position'];
         "text": TooltipProps['text'];
@@ -131,6 +148,14 @@ export interface MntFieldTextCustomEvent<T> extends CustomEvent<T> {
 export interface MntStepsCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLMntStepsElement;
+}
+export interface MntTabItemCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLMntTabItemElement;
+}
+export interface MntTabItemGroupCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLMntTabItemGroupElement;
 }
 declare global {
     interface HTMLMntBadgeElement extends Components.MntBadge, HTMLStencilElement {
@@ -250,6 +275,40 @@ declare global {
         prototype: HTMLMntStepsElement;
         new (): HTMLMntStepsElement;
     };
+    interface HTMLMntTabItemElementEventMap {
+        "tabItemClick": string;
+    }
+    interface HTMLMntTabItemElement extends Components.MntTabItem, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLMntTabItemElementEventMap>(type: K, listener: (this: HTMLMntTabItemElement, ev: MntTabItemCustomEvent<HTMLMntTabItemElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLMntTabItemElementEventMap>(type: K, listener: (this: HTMLMntTabItemElement, ev: MntTabItemCustomEvent<HTMLMntTabItemElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLMntTabItemElement: {
+        prototype: HTMLMntTabItemElement;
+        new (): HTMLMntTabItemElement;
+    };
+    interface HTMLMntTabItemGroupElementEventMap {
+        "tabChange": string;
+    }
+    interface HTMLMntTabItemGroupElement extends Components.MntTabItemGroup, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLMntTabItemGroupElementEventMap>(type: K, listener: (this: HTMLMntTabItemGroupElement, ev: MntTabItemGroupCustomEvent<HTMLMntTabItemGroupElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLMntTabItemGroupElementEventMap>(type: K, listener: (this: HTMLMntTabItemGroupElement, ev: MntTabItemGroupCustomEvent<HTMLMntTabItemGroupElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLMntTabItemGroupElement: {
+        prototype: HTMLMntTabItemGroupElement;
+        new (): HTMLMntTabItemGroupElement;
+    };
     interface HTMLMntTooltipElement extends Components.MntTooltip, HTMLStencilElement {
     }
     var HTMLMntTooltipElement: {
@@ -267,6 +326,8 @@ declare global {
         "mnt-icon-large": HTMLMntIconLargeElement;
         "mnt-illustration": HTMLMntIllustrationElement;
         "mnt-steps": HTMLMntStepsElement;
+        "mnt-tab-item": HTMLMntTabItemElement;
+        "mnt-tab-item-group": HTMLMntTabItemGroupElement;
         "mnt-tooltip": HTMLMntTooltipElement;
     }
 }
@@ -367,6 +428,21 @@ declare namespace LocalJSX {
         "orientation"?: StepsProps['orientation'];
         "steps"?: StepsProps['steps'];
     }
+    interface MntTabItem {
+        "disabled"?: boolean;
+        "icon"?: TabItemProps['icon'];
+        "label": string;
+        "onTabItemClick"?: (event: MntTabItemCustomEvent<string>) => void;
+        "orientation"?: TabItemProps['orientation'];
+        "selected"?: boolean;
+        "tabId": string;
+    }
+    interface MntTabItemGroup {
+        "onTabChange"?: (event: MntTabItemGroupCustomEvent<string>) => void;
+        "orientation"?: TabItemGroupProps['orientation'];
+        "selectedId"?: string;
+        "tabs": TabItem[] | string;
+    }
     interface MntTooltip {
         "position"?: TooltipProps['position'];
         "text"?: TooltipProps['text'];
@@ -382,6 +458,8 @@ declare namespace LocalJSX {
         "mnt-icon-large": MntIconLarge;
         "mnt-illustration": MntIllustration;
         "mnt-steps": MntSteps;
+        "mnt-tab-item": MntTabItem;
+        "mnt-tab-item-group": MntTabItemGroup;
         "mnt-tooltip": MntTooltip;
     }
 }
@@ -399,6 +477,8 @@ declare module "@stencil/core" {
             "mnt-icon-large": LocalJSX.MntIconLarge & JSXBase.HTMLAttributes<HTMLMntIconLargeElement>;
             "mnt-illustration": LocalJSX.MntIllustration & JSXBase.HTMLAttributes<HTMLMntIllustrationElement>;
             "mnt-steps": LocalJSX.MntSteps & JSXBase.HTMLAttributes<HTMLMntStepsElement>;
+            "mnt-tab-item": LocalJSX.MntTabItem & JSXBase.HTMLAttributes<HTMLMntTabItemElement>;
+            "mnt-tab-item-group": LocalJSX.MntTabItemGroup & JSXBase.HTMLAttributes<HTMLMntTabItemGroupElement>;
             "mnt-tooltip": LocalJSX.MntTooltip & JSXBase.HTMLAttributes<HTMLMntTooltipElement>;
         }
     }

--- a/src/components/tab-item-group/readme.md
+++ b/src/components/tab-item-group/readme.md
@@ -1,0 +1,47 @@
+# mnt-tab-item-group
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property            | Attribute     | Description | Type                         | Default        |
+| ------------------- | ------------- | ----------- | ---------------------------- | -------------- |
+| `orientation`       | `orientation` |             | `"horizontal" \| "vertical"` | `'horizontal'` |
+| `selectedId`        | `selected-id` |             | `string`                     | `undefined`    |
+| `tabs` _(required)_ | `tabs`        |             | `TabItem[] \| string`        | `undefined`    |
+
+
+## Events
+
+| Event       | Description | Type                  |
+| ----------- | ----------- | --------------------- |
+| `tabChange` |             | `CustomEvent<string>` |
+
+
+## Shadow Parts
+
+| Part          | Description |
+| ------------- | ----------- |
+| `"tab-group"` |             |
+
+
+## Dependencies
+
+### Depends on
+
+- [mnt-tab-item](../tab-item)
+
+### Graph
+```mermaid
+graph TD;
+  mnt-tab-item-group --> mnt-tab-item
+  mnt-tab-item --> mnt-icon
+  style mnt-tab-item-group fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/tab-item-group/styles/__base.scss
+++ b/src/components/tab-item-group/styles/__base.scss
@@ -1,0 +1,11 @@
+@use "sass:map";
+@use "../../../shared/theme/core/theme" as theme;
+@use "../../../shared/theme/tokens/sizing" as sizing;
+
+$component-prefix: theme.get-prefix('tab-item-group');
+
+$border-radius-medium: map.get(sizing.$border-radius-map, "medium");
+
+.#{$component-prefix} {
+  @include theme.set-box-sizing(border-box);
+}

--- a/src/components/tab-item-group/styles/_orientation-horizontal.scss
+++ b/src/components/tab-item-group/styles/_orientation-horizontal.scss
@@ -1,0 +1,12 @@
+@use "sass:map";
+@use "../../../shared/theme/core/theme" as theme;
+
+$component-prefix: theme.get-prefix('tab-item-group');
+
+@mixin set-tab-group-horizontal-styles() {
+  .#{$component-prefix}-horizontal {
+    flex-direction: row;
+    align-items: center;
+    margin-bottom: 16px;
+  }
+}

--- a/src/components/tab-item-group/styles/_orientation-vertical.scss
+++ b/src/components/tab-item-group/styles/_orientation-vertical.scss
@@ -1,0 +1,13 @@
+@use "sass:map";
+@use "../../../shared/theme/core/theme" as theme;
+
+$component-prefix: theme.get-prefix('tab-item-group');
+
+@mixin set-tab-group-vertical-styles() {
+  .#{$component-prefix}-vertical {
+    @debug 'component-prefix: #{$component-prefix}';
+    flex-direction: column;
+    align-items: stretch;
+    width: fit-content;
+  }
+}

--- a/src/components/tab-item-group/styles/index.scss
+++ b/src/components/tab-item-group/styles/index.scss
@@ -1,0 +1,16 @@
+/**
+ * This file is a barrel file for the styles of the TabItemGroup component.
+ *
+ * WARNING: Please do not add any CSS rules directly to this file!
+ * Check [index.scss](./styles/index.scss) to know how to organize component's stylesheets
+ **/
+
+@use "sass:map";
+
+@forward "./__base"; // Base styles for the tab-item-group component
+
+@use "./_orientation-horizontal" as tab-group-horizontal;
+@use "./_orientation-vertical" as tab-group-vertical;
+
+@include tab-group-horizontal.set-tab-group-horizontal-styles();
+@include tab-group-vertical.set-tab-group-vertical-styles();

--- a/src/components/tab-item-group/tab-item-group.scss
+++ b/src/components/tab-item-group/tab-item-group.scss
@@ -1,0 +1,12 @@
+/**
+  * This file is a barrel file for the styles of the TabItemGroup component.
+  *
+  * WARNING: Please do not add any CSS rules directly to this file!
+  * Check [index.scss](./styles/index.scss) to know how to organize component's stylesheets
+  **/
+
+@use '../../shared/theme/core/theme' as theme;
+@use '../../shared/theme/core/typography' as typography;
+@use '../../shared/theme/tokens/sizing' as sizing;
+
+@forward './styles/index.scss';

--- a/src/components/tab-item-group/tab-item-group.spec.tsx
+++ b/src/components/tab-item-group/tab-item-group.spec.tsx
@@ -1,0 +1,106 @@
+import { newSpecPage } from '@stencil/core/testing';
+
+// import { getLibPrefix } from 'src/utils/utils';
+import { TabItemGroup } from './tab-item-group';
+
+// const LIB_PREFIX = getLibPrefix();
+
+const mockTabs = [
+  { id: 'tab-1', label: 'Tab 1', icon: 'plus' },
+  { id: 'tab-2', label: 'Tab 2', icon: 'minus' },
+  { id: 'tab-3', label: 'Tab 3', disabled: true },
+];
+
+describe('<mnt-tab-item-group>', () => {
+  describe('Rendering', () => {
+    it('SHOULD render correctly WHEN has tabs array', async () => {
+      // SETUP
+      const page = await newSpecPage({
+        components: [TabItemGroup],
+        template: () => `<mnt-tab-item-group tabs='${JSON.stringify(mockTabs)}'></mnt-tab-item-group>`,
+      });
+
+      // ASSERTION
+      expect(page.root).toBeTruthy();
+    });
+
+    it('SHOULD render nothing WHEN tabs array is empty', async () => {
+      // SETUP
+      const page = await newSpecPage({
+        components: [TabItemGroup],
+        template: () => `<mnt-tab-item-group tabs='[]'></mnt-tab-item-group>`,
+      });
+
+      // ASSERTION
+      expect(page.root).toBeTruthy();
+    });
+  });
+
+  describe('Props and Attributes', () => {
+    it('SHOULD apply correct orientation class', async () => {
+      // SETUP
+      const page = await newSpecPage({
+        components: [TabItemGroup],
+        template: () => `<mnt-tab-item-group tabs='${JSON.stringify(mockTabs)}' orientation="vertical"></mnt-tab-item-group>`,
+      });
+
+      // ASSERTION
+      expect(page.root).toBeTruthy();
+    });
+
+    it('SHOULD use horizontal orientation as default', async () => {
+      // SETUP
+      const page = await newSpecPage({
+        components: [TabItemGroup],
+        template: () => `<mnt-tab-item-group tabs='${JSON.stringify(mockTabs)}'></mnt-tab-item-group>`,
+      });
+
+      // ASSERTION
+      expect(page.root).toBeTruthy();
+    });
+  });
+
+  describe('Selection Logic', () => {
+    it('SHOULD select first tab by default WHEN no selectedId provided', async () => {
+      // SETUP
+      const page = await newSpecPage({
+        components: [TabItemGroup],
+        template: () => `<mnt-tab-item-group tabs='${JSON.stringify(mockTabs)}'></mnt-tab-item-group>`,
+      });
+
+      // ASSERTION
+      expect(page.root).toBeTruthy();
+    });
+
+    it('SHOULD select specified tab WHEN selectedId provided', async () => {
+      // SETUP
+      const page = await newSpecPage({
+        components: [TabItemGroup],
+        template: () => `<mnt-tab-item-group tabs='${JSON.stringify(mockTabs)}' selected-id="tab-2"></mnt-tab-item-group>`,
+      });
+
+      // ASSERTION
+      expect(page.root).toBeTruthy();
+    });
+  });
+
+  describe('Events', () => {
+    it('SHOULD emit tabChange event WHEN tab is clicked', async () => {
+      // SETUP
+      const page = await newSpecPage({
+        components: [TabItemGroup],
+        template: () => `<mnt-tab-item-group tabs='${JSON.stringify(mockTabs)}'></mnt-tab-item-group>`,
+      });
+
+      const spy = jest.fn();
+      page.root.addEventListener('tabChange', spy);
+
+      // ACTION
+      // Simulate tab click by dispatching event
+      page.root.dispatchEvent(new CustomEvent('tabChange', { detail: 'tab-2' }));
+
+      // ASSERTION
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/tab-item-group/tab-item-group.stories.ts
+++ b/src/components/tab-item-group/tab-item-group.stories.ts
@@ -1,0 +1,375 @@
+import type { Meta, StoryFn } from '@storybook/html';
+
+import { tabOrientationArray } from '../tab-item/tab-item.types';
+import type { TabItemGroupProps, TabItem } from './tab-item-group.types';
+import { HTMLString } from 'src/utils/utils';
+import { TabItemGroup } from './tab-item-group';
+
+// const SB_TABLE_ICON = {
+//   type: {
+//     summary: ICON_OPTIONS.join(' | '),
+//   },
+// };
+
+const mockTabs: TabItem[] = [
+  { id: 'tab-1', label: 'Overview', icon: 'houseSimple' },
+  { id: 'tab-2', label: 'Settings', icon: 'wrench' },
+  { id: 'tab-3', label: 'Favorites', icon: 'starOutline' },
+  { id: 'tab-4', label: 'Notifications', icon: 'bell' },
+];
+
+const mockTabsWithDisabled: TabItem[] = [
+  { id: 'tab-1', label: 'Overview', icon: 'houseSimple' },
+  { id: 'tab-2', label: 'Settings', icon: 'wrench' },
+  { id: 'tab-3', label: 'Favorites', icon: 'starOutline', disabled: true },
+  { id: 'tab-4', label: 'Notifications', icon: 'bell' },
+];
+
+const mockTabsWithoutIcons: TabItem[] = [
+  { id: 'tab-1', label: 'Overview' },
+  { id: 'tab-2', label: 'Analytics' },
+  { id: 'tab-3', label: 'Settings' },
+  { id: 'tab-4', label: 'Profile' },
+];
+
+const meta: Meta<TabItemGroupProps> = {
+  title: 'Navigation/Tab/TabItemGroup',
+  component: 'mnt-tab-item-group',
+  argTypes: {
+    tabs: {
+      control: 'object',
+      description: 'Array of tab items to display',
+      table: {
+        type: { summary: 'TabItem[]' },
+        defaultValue: { summary: '[]' },
+      },
+    },
+    selectedId: {
+      control: 'text',
+      description: 'ID of the currently selected tab',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+    orientation: {
+      control: 'select',
+      options: tabOrientationArray,
+      description: 'Orientation of the tab group',
+      table: {
+        defaultValue: { summary: 'horizontal' },
+        type: { summary: tabOrientationArray.join(' | ') },
+      },
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '**TabItemGroup** é um componente de navegação que organiza e gerencia uma coleção de abas (tabs) para facilitar a navegação entre diferentes seções de conteúdo.\n\n' +
+          '### 🎯 **Características principais:**\n' +
+          '- **Navegação intuitiva:** Permite alternar entre diferentes seções de forma clara e organizada\n' +
+          '- **Orientação flexível:** Suporte a layout horizontal (padrão) e vertical\n' +
+          '- **Ícones opcionais:** Cada tab pode ter um ícone para melhor identificação visual\n' +
+          '- **Estados visuais:** Diferenciação clara entre tabs ativas, inativas e desabilitadas\n' +
+          '- **Controle de estado:** Gerenciamento automático ou controlado da seleção\n' +
+          '- **Acessibilidade:** Suporte completo a navegação por teclado e screen readers\n\n' +
+          '### 📏 **Orientações disponíveis:**\n' +
+          '- **Horizontal:** Ideal para navegação principal em headers ou seções superiores\n' +
+          '- **Vertical:** Perfeito para sidebars, menus laterais ou navegação secundária\n\n' +
+          '### 🎨 **Estados das tabs:**\n' +
+          '- **Default:** Estado normal, clicável e disponível\n' +
+          '- **Selected:** Tab atualmente selecionada (destaque visual)\n' +
+          '- **Disabled:** Tab desabilitada, não clicável\n' +
+          '- **Hover:** Estado de interação ao passar o mouse\n\n' +
+          '### 🔧 **API do componente:**\n' +
+          '- **Props:** `tabs`, `selectedId`, `orientation`\n' +
+          '- **Eventos:** `tabChange` - emitido quando uma tab é selecionada\n' +
+          '- **Métodos:** Gerenciamento automático de estado interno\n\n' +
+          '### 💡 **Casos de uso:**\n' +
+          '- Navegação principal de aplicações\n' +
+          '- Seções de configurações\n' +
+          '- Dashboards e painéis administrativos\n' +
+          '- Formulários multi-etapas\n' +
+          '- Filtros e categorias\n\n' +
+          '**Figma:** [Global Assets | Tab](https://www.figma.com/design/ezr4b0ZxjmeWjASveGQoJS/-1-Core-Components?node-id=407-2410&m=dev)\n\n',
+      },
+    },
+  },
+};
+
+export default meta;
+
+const DefaultTemplate = (args: TabItemGroupProps): HTMLString => `
+  <mnt-tab-item-group
+    tabs='${JSON.stringify(args.tabs)}'
+    selected-id="${args.selectedId || ''}"
+    orientation="${args.orientation}"
+  ></mnt-tab-item-group>
+
+  <script>
+    // Debug: verificar se o componente foi renderizado
+    setTimeout(() => {
+      const component = document.querySelector('mnt-tab-item-group');
+      console.log('TabItemGroup component:', component);
+      if (component) {
+        console.log('Component tabs:', component.tabs);
+        console.log('Component selectedId:', component.selectedId);
+        console.log('Component orientation:', component.orientation);
+      }
+    }, 100);
+  </script>
+`;
+
+export const Default: StoryFn = DefaultTemplate.bind({});
+Default.args = {
+  tabs: mockTabs,
+  selectedId: 'tab-1',
+  orientation: 'horizontal',
+} as TabItemGroupProps;
+Default.storyName = 'Playground';
+Default.parameters = {
+  id: 'tab-item-group-playground',
+  docs: {
+    description: {
+      story: 'Playground do componente `<mnt-tab-item-group>`. Use os controles para testar diferentes configurações.',
+    },
+  },
+};
+
+// Teste simples para verificar se o componente está funcionando
+export const SimpleTest: StoryFn = () => `
+  <div>
+    <h3>Teste Simples - TabItem Individual</h3>
+    <mnt-tab-item tab-id="test-1" label="Test Tab 1" selected="true" orientation="horizontal"></mnt-tab-item>
+    <mnt-tab-item tab-id="test-2" label="Test Tab 2" selected="false" orientation="horizontal"></mnt-tab-item>
+  </div>
+  
+  <div style="margin-top: 20px;">
+    <h3>Teste Simples - TabItemGroup</h3>
+    <mnt-tab-item-group
+      tabs='[{"id":"tab-1","label":"Overview","icon":"house"},{"id":"tab-2","label":"Analytics","icon":"chartBar"}]'
+      selected-id="tab-1"
+      orientation="horizontal"
+    ></mnt-tab-item-group>
+  </div>
+  
+  <script>
+    setTimeout(() => {
+      console.log('=== DEBUG TAB COMPONENTS ===');
+      const tabItems = document.querySelectorAll('mnt-tab-item');
+      console.log('TabItem elements found:', tabItems.length);
+      tabItems.forEach((item, index) => {
+        console.log(\`TabItem \${index}:\`, item);
+        console.log(\`  - tabId: \${item.tabId}\`);
+        console.log(\`  - label: \${item.label}\`);
+        console.log(\`  - selected: \${item.selected}\`);
+      });
+      
+      const tabGroup = document.querySelector('mnt-tab-item-group');
+      console.log('TabItemGroup element:', tabGroup);
+      if (tabGroup) {
+        console.log('  - tabs:', tabGroup.tabs);
+        console.log('  - selectedId:', tabGroup.selectedId);
+        console.log('  - orientation:', tabGroup.orientation);
+      }
+    }, 500);
+  </script>
+`;
+
+SimpleTest.storyName = 'Simple Test';
+SimpleTest.parameters = {
+  id: 'tab-simple-test',
+  docs: {
+    description: {
+      story: 'Teste simples para verificar se os componentes Tab estão funcionando corretamente.',
+    },
+  },
+  controls: { disable: true },
+};
+
+export const WithIcons: StoryFn<typeof TabItemGroup> = () => {
+  return DefaultTemplate({
+    tabs: mockTabs,
+    selectedId: 'tab-2',
+    orientation: 'horizontal',
+  });
+};
+
+WithIcons.storyName = 'With Icons';
+WithIcons.parameters = {
+  id: 'tab-item-group-with-icons',
+  docs: {
+    description: {
+      story: 'Tabs com ícones para melhor identificação visual. Cada tab pode ter um ícone opcional que melhora a experiência do usuário.',
+    },
+  },
+  controls: { disable: true },
+};
+
+export const WithoutIcons: StoryFn<typeof TabItemGroup> = () => {
+  return DefaultTemplate({
+    tabs: mockTabsWithoutIcons,
+    selectedId: 'tab-1',
+    orientation: 'horizontal',
+  });
+};
+
+WithoutIcons.storyName = 'Without Icons';
+WithoutIcons.parameters = {
+  id: 'tab-item-group-without-icons',
+  docs: {
+    description: {
+      story: 'Tabs sem ícones, usando apenas texto. Ideal para interfaces mais minimalistas ou quando o espaço é limitado.',
+    },
+  },
+  controls: { disable: true },
+};
+
+export const WithDisabledTabs: StoryFn<typeof TabItemGroup> = () => {
+  return DefaultTemplate({
+    tabs: mockTabsWithDisabled,
+    selectedId: 'tab-1',
+    orientation: 'horizontal',
+  });
+};
+
+WithDisabledTabs.storyName = 'With Disabled Tabs';
+WithDisabledTabs.parameters = {
+  id: 'tab-item-group-disabled',
+  docs: {
+    description: {
+      story: 'Tabs com algumas opções desabilitadas. Tabs desabilitadas não são clicáveis e têm aparência visual diferenciada para indicar indisponibilidade.',
+    },
+  },
+  controls: { disable: true },
+};
+
+export const VerticalOrientation: StoryFn<typeof TabItemGroup> = () => {
+  return DefaultTemplate({
+    tabs: mockTabs,
+    selectedId: 'tab-1',
+    orientation: 'vertical',
+  });
+};
+
+VerticalOrientation.storyName = 'Vertical Orientation';
+VerticalOrientation.parameters = {
+  id: 'tab-item-group-vertical',
+  docs: {
+    description: {
+      story: 'Tabs organizadas verticalmente. Ideal para sidebars, menus laterais ou quando há muitas opções de navegação.',
+    },
+  },
+  controls: { disable: true },
+};
+
+export const VerticalWithoutIcons: StoryFn<typeof TabItemGroup> = () => {
+  return DefaultTemplate({
+    tabs: mockTabsWithoutIcons,
+    selectedId: 'tab-2',
+    orientation: 'vertical',
+  });
+};
+
+VerticalWithoutIcons.storyName = 'Vertical Without Icons';
+VerticalWithoutIcons.parameters = {
+  id: 'tab-item-group-vertical-no-icons',
+  docs: {
+    description: {
+      story: 'Tabs verticais sem ícones. Combinação de orientação vertical com design minimalista usando apenas texto.',
+    },
+  },
+  controls: { disable: true },
+};
+
+export const AllVariants: StoryFn<typeof TabItemGroup> = () => {
+  const variants: HTMLString[] = [];
+
+  // Horizontal with icons
+  variants.push(`
+    <div class="sb-section-box">
+      <h4>Horizontal with Icons</h4>
+      <div class="sb-grid-1">
+        ${DefaultTemplate({
+          tabs: mockTabs,
+          selectedId: 'tab-2',
+          orientation: 'horizontal',
+        })}
+      </div>
+    </div>
+  `);
+
+  // Horizontal without icons
+  variants.push(`
+    <div class="sb-section-box">
+      <h4>Horizontal without Icons</h4>
+      <div class="sb-grid-1">
+        ${DefaultTemplate({
+          tabs: mockTabsWithoutIcons,
+          selectedId: 'tab-1',
+          orientation: 'horizontal',
+        })}
+      </div>
+    </div>
+  `);
+
+  // Vertical with icons
+  variants.push(`
+    <div class="sb-section-box">
+      <h4>Vertical with Icons</h4>
+      <div class="sb-grid-1">
+        ${DefaultTemplate({
+          tabs: mockTabs,
+          selectedId: 'tab-3',
+          orientation: 'vertical',
+        })}
+      </div>
+    </div>
+  `);
+
+  // Vertical without icons
+  variants.push(`
+    <div class="sb-section-box">
+      <h4>Vertical without Icons</h4>
+      <div class="sb-grid-1">
+        ${DefaultTemplate({
+          tabs: mockTabsWithoutIcons,
+          selectedId: 'tab-2',
+          orientation: 'vertical',
+        })}
+      </div>
+    </div>
+  `);
+
+  // With disabled tabs
+  variants.push(`
+    <div class="sb-section-box">
+      <h4>With Disabled Tabs</h4>
+      <div class="sb-grid-1">
+        ${DefaultTemplate({
+          tabs: mockTabsWithDisabled,
+          selectedId: 'tab-1',
+          orientation: 'horizontal',
+        })}
+      </div>
+    </div>
+  `);
+
+  return `
+    <div>
+      ${variants.join('')}
+    </div>
+  `;
+};
+
+AllVariants.storyName = 'All Variants';
+AllVariants.parameters = {
+  id: 'tab-item-group-all-variants',
+  docs: {
+    description: {
+      story: 'Visão geral de todas as variações do componente TabItemGroup, incluindo diferentes orientações, presença de ícones e estados desabilitados.',
+    },
+  },
+  controls: { disable: true },
+};

--- a/src/components/tab-item-group/tab-item-group.tsx
+++ b/src/components/tab-item-group/tab-item-group.tsx
@@ -1,0 +1,95 @@
+import { Component, Host, Prop, Event, EventEmitter, h, State, Watch } from '@stencil/core';
+
+import { setComponentClass } from '../../utils/utils';
+import { TabItem } from './tab-item-group.types';
+import { TabItemGroupProps } from './tab-item-group.types';
+
+@Component({
+  tag: 'mnt-tab-item-group',
+  styleUrl: 'tab-item-group.scss',
+  shadow: false,
+})
+export class TabItemGroup {
+  @Prop() tabs!: TabItem[] | string;
+  @Prop() selectedId?: string;
+  @Prop() orientation: TabItemGroupProps['orientation'] = 'horizontal';
+
+  private get parsedTabs(): TabItem[] {
+    if (typeof this.tabs === 'string') {
+      try {
+        return JSON.parse(this.tabs);
+      } catch (e) {
+        console.error('Failed to parse tabs:', e);
+        return [];
+      }
+    }
+    return this.tabs || [];
+  }
+
+  @Event() tabChange: EventEmitter<string>;
+
+  @State() internalSelectedId: string = '';
+
+  componentWillLoad() {
+    this.updateSelectedId();
+  }
+
+  @Watch('tabs')
+  @Watch('selectedId')
+  onTabsOrSelectedIdChange() {
+    this.updateSelectedId();
+  }
+
+  private updateSelectedId() {
+    const tabs = this.parsedTabs;
+    if (this.selectedId !== undefined) {
+      this.internalSelectedId = this.selectedId;
+    } else if (tabs && tabs.length > 0) {
+      // Select first non-disabled tab, or first tab if all are disabled
+      const firstEnabledTab = tabs.find((tab: TabItem) => !tab.disabled);
+      this.internalSelectedId = firstEnabledTab ? firstEnabledTab.id : tabs[0].id;
+    }
+  }
+
+  private handleTabClick = (event: CustomEvent<string>) => {
+    const tabId = event.detail;
+    this.internalSelectedId = tabId;
+    this.tabChange.emit(tabId);
+  };
+
+  get groupClass() {
+    return setComponentClass('tab-item-group', this.orientation);
+  }
+
+  private renderTabItem(tab: TabItem) {
+    return (
+      <mnt-tab-item
+        tabId={tab.id}
+        label={tab.label}
+        icon={tab.icon}
+        selected={this.internalSelectedId === tab.id}
+        disabled={tab.disabled}
+        orientation={this.orientation}
+        onTabItemClick={this.handleTabClick}
+      />
+    );
+  }
+
+  render() {
+    const tabs = this.parsedTabs;
+    if (!tabs || tabs.length === 0) {
+      return null;
+    }
+
+    return (
+      <Host>
+        <div
+          class={this.groupClass}
+          part="tab-group"
+        >
+          {tabs.map((tab: TabItem) => this.renderTabItem(tab))}
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/components/tab-item-group/tab-item-group.types.ts
+++ b/src/components/tab-item-group/tab-item-group.types.ts
@@ -1,0 +1,16 @@
+import type { TabOrientation } from '../tab-item/tab-item.types';
+
+export const componentPrefix = 'tab-item-group';
+
+export interface TabItem {
+  id: string;
+  label: string;
+  icon?: string;
+  disabled?: boolean;
+}
+
+export interface TabItemGroupProps {
+  tabs: TabItem[];
+  selectedId?: string;
+  orientation?: TabOrientation;
+}

--- a/src/components/tab-item/readme.md
+++ b/src/components/tab-item/readme.md
@@ -1,0 +1,54 @@
+# mnt-tab-item
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property             | Attribute     | Description | Type                         | Default        |
+| -------------------- | ------------- | ----------- | ---------------------------- | -------------- |
+| `disabled`           | `disabled`    |             | `boolean`                    | `false`        |
+| `icon`               | `icon`        |             | `string`                     | `undefined`    |
+| `label` _(required)_ | `label`       |             | `string`                     | `undefined`    |
+| `orientation`        | `orientation` |             | `"horizontal" \| "vertical"` | `'horizontal'` |
+| `selected`           | `selected`    |             | `boolean`                    | `false`        |
+| `tabId` _(required)_ | `tab-id`      |             | `string`                     | `undefined`    |
+
+
+## Events
+
+| Event          | Description | Type                  |
+| -------------- | ----------- | --------------------- |
+| `tabItemClick` |             | `CustomEvent<string>` |
+
+
+## Shadow Parts
+
+| Part         | Description |
+| ------------ | ----------- |
+| `"tab-item"` |             |
+
+
+## Dependencies
+
+### Used by
+
+ - [mnt-tab-item-group](../tab-item-group)
+
+### Depends on
+
+- [mnt-icon](../icon)
+
+### Graph
+```mermaid
+graph TD;
+  mnt-tab-item --> mnt-icon
+  mnt-tab-item-group --> mnt-tab-item
+  style mnt-tab-item fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/tab-item/styles/__base.scss
+++ b/src/components/tab-item/styles/__base.scss
@@ -1,0 +1,68 @@
+@use "sass:map";
+@use "../../../shared/theme/core/theme" as theme;
+@use "../../../shared/theme/tokens/sizing" as sizing;
+
+$component-prefix: theme.get-prefix('tab-item');
+$border-radius-medium: map.get(sizing.$border-radius-map, "medium");
+
+div[class^='mnt-tab-item-group']{
+  display: flex;
+  gap: 16px;
+  border-color: #E5E7E8;
+}
+
+.#{$component-prefix} {
+  @include theme.set-colors(theme.get-tone-from-palette(700, 'neutral'), transparent);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: none;
+  border-radius: $border-radius-medium;
+  padding: 8px 16px;
+  transition: all ease-in-out 0.2s;
+  cursor: pointer;
+
+  // ICON VARIANT
+
+  &-icon {
+    flex-direction: column;
+  }
+
+  &:not(&-icon) {
+    flex-direction: row;
+    height: 32px;
+  }
+
+  // ELEMENTS
+
+  &-label {
+    white-space: nowrap;
+    text-align: center;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 20px;
+  }
+
+  mnt-icon svg g {
+    color: currentColor;
+    fill: currentColor;
+  }
+
+  // STATES
+
+  &:hover {
+    background: theme.get-tone-from-palette(50, 'neutral');
+    color: theme.get-tone-from-palette(800, 'neutral');
+    cursor: pointer;
+  }
+
+  &-selected {
+    background: theme.get-tone-from-palette(100, 'primary');
+    color: theme.get-tone-from-palette(800, 'primary');
+
+    &:hover {
+      background: theme.get-tone-from-palette(200, 'primary');
+      color: theme.get-tone-from-palette(900, 'primary');
+    }
+  }
+}

--- a/src/components/tab-item/styles/_orientation-horizontal.scss
+++ b/src/components/tab-item/styles/_orientation-horizontal.scss
@@ -1,0 +1,38 @@
+@use "sass:map";
+@use "../../../shared/theme/core/theme" as theme;
+
+$component-prefix: theme.get-prefix('tab-item-group-horizontal');
+$child-prefix: theme.get-prefix('tab-item');
+
+@mixin set-tab-horizontal-styles() {
+  .#{$component-prefix} {
+    flex-direction: row;
+    min-height: 40px;
+    gap: 4px;
+    border-bottom: 2px solid;
+    padding-bottom: 4px;
+
+    .#{$child-prefix}-selected:not(&-icon) {
+      position: relative;
+
+      &::after {
+        content: '';
+        position: absolute;
+        display: block;
+        width: 100%;
+        height: 4px;
+        border-radius: 4px;
+        background: #0B7CBE;
+        margin: auto;
+        left: 0;
+        bottom: -12px;
+      }
+    }
+
+    .#{$child-prefix}-icon.#{$child-prefix}-selected {
+      &::after {
+        bottom: -8px;
+      }
+    }
+  }
+}

--- a/src/components/tab-item/styles/_orientation-vertical.scss
+++ b/src/components/tab-item/styles/_orientation-vertical.scss
@@ -1,0 +1,28 @@
+@use "sass:map";
+@use "../../../shared/theme/core/theme" as theme;
+
+$component-prefix: theme.get-prefix('tab-item-group-vertical');
+$child-prefix: theme.get-prefix('tab-item');
+
+@mixin set-tab-vertical-styles() {
+  .#{$component-prefix} {
+    flex-direction: column;
+
+    .#{$child-prefix}-selected {
+      position: relative;
+
+      &::after {
+        content: '';
+        position: absolute;
+        display: block;
+        width: 100%;
+        height: 4px;
+        border-radius: 4px;
+        background: #0B7CBE;
+        margin: auto;
+        left: 0;
+        bottom: -12px;
+      }
+    }
+  }
+}

--- a/src/components/tab-item/styles/index.scss
+++ b/src/components/tab-item/styles/index.scss
@@ -1,0 +1,16 @@
+/**
+ * This file is a barrel file for the styles of the TabItem component.
+ *
+ * WARNING: Please do not add any CSS rules directly to this file!
+ * Check [index.scss](./styles/index.scss) to know how to organize component's stylesheets
+ **/
+
+@use "sass:map";
+
+@forward "./__base"; // Base styles for the tab-item component
+
+@use "./_orientation-horizontal" as tab-horizontal;
+@use "./_orientation-vertical" as tab-vertical;
+
+@include tab-horizontal.set-tab-horizontal-styles();
+@include tab-vertical.set-tab-vertical-styles();

--- a/src/components/tab-item/tab-item.scss
+++ b/src/components/tab-item/tab-item.scss
@@ -1,0 +1,12 @@
+/**
+  * This file is a barrel file for the styles of the TabItem component.
+  *
+  * WARNING: Please do not add any CSS rules directly to this file!
+  * Check [index.scss](./styles/index.scss) to know how to organize component's stylesheets
+  **/
+
+@use '../../shared/theme/core/theme' as theme;
+@use '../../shared/theme/core/typography' as typography;
+@use '../../shared/theme/tokens/sizing' as sizing;
+
+@forward './styles/index.scss';

--- a/src/components/tab-item/tab-item.spec.tsx
+++ b/src/components/tab-item/tab-item.spec.tsx
@@ -1,0 +1,131 @@
+import { newSpecPage } from '@stencil/core/testing';
+
+import { getLibPrefix } from 'src/utils/utils';
+import { TabItem } from './tab-item';
+
+const LIB_PREFIX = getLibPrefix();
+
+const DEFAULT_TAB_ID = 'tab-1';
+const DEFAULT_LABEL = 'Tab Label';
+const DEFAULT_ICON = 'plus';
+
+async function createTabItemComponent(html: string) {
+  return await newSpecPage({
+    components: [TabItem],
+    html,
+  });
+}
+
+function getTabItemElement(page: any) {
+  return page.root.querySelector('button');
+}
+
+describe('<mnt-tab-item>', () => {
+  describe('Rendering', () => {
+    it('SHOULD render correctly WHEN has required props', async () => {
+      // SETUP
+      const page = await createTabItemComponent(`<mnt-tab-item tab-id="${DEFAULT_TAB_ID}" label="${DEFAULT_LABEL}"></mnt-tab-item>`);
+      const button = getTabItemElement(page);
+      const label = button.querySelector('.tab-item-label');
+
+      // ASSERTION
+      expect(label.textContent).toBe(DEFAULT_LABEL);
+      expect(button).toHaveClass(`${LIB_PREFIX}tab-item-horizontal`);
+    });
+
+    it('SHOULD render with icon WHEN icon prop is provided', async () => {
+      // SETUP
+      const page = await createTabItemComponent(`<mnt-tab-item tab-id="${DEFAULT_TAB_ID}" label="${DEFAULT_LABEL}" icon="${DEFAULT_ICON}"></mnt-tab-item>`);
+      const icon = page.root.querySelector('.tab-item-icon');
+
+      // ASSERTION
+      expect(icon).not.toBeNull();
+      expect(icon.tagName.toLowerCase()).toBe('mnt-icon');
+      expect(icon.getAttribute('icon')).toBe(DEFAULT_ICON);
+    });
+
+    it('SHOULD NOT render icon WHEN icon prop is not provided', async () => {
+      // SETUP
+      const page = await createTabItemComponent(`<mnt-tab-item tab-id="${DEFAULT_TAB_ID}" label="${DEFAULT_LABEL}"></mnt-tab-item>`);
+      const icon = page.root.querySelector('.tab-item-icon');
+
+      // ASSERTION
+      expect(icon).toBeNull();
+    });
+  });
+
+  describe('Props and Attributes', () => {
+    it('SHOULD apply correct classes WHEN orientation is provided', async () => {
+      // SETUP
+      const page = await createTabItemComponent(`<mnt-tab-item tab-id="${DEFAULT_TAB_ID}" label="${DEFAULT_LABEL}" orientation="vertical"></mnt-tab-item>`);
+      const button = getTabItemElement(page);
+
+      // ASSERTION
+      expect(button).toHaveClass(`${LIB_PREFIX}tab-item-vertical`);
+    });
+
+    it('SHOULD apply selected class WHEN selected is true', async () => {
+      // SETUP
+      const page = await createTabItemComponent(`<mnt-tab-item tab-id="${DEFAULT_TAB_ID}" label="${DEFAULT_LABEL}" selected="true"></mnt-tab-item>`);
+      const button = getTabItemElement(page);
+
+      // ASSERTION
+      expect(button).toHaveClass(`${LIB_PREFIX}tab-item-selected`);
+    });
+
+    it('SHOULD apply disabled class WHEN disabled is true', async () => {
+      // SETUP
+      const page = await createTabItemComponent(`<mnt-tab-item tab-id="${DEFAULT_TAB_ID}" label="${DEFAULT_LABEL}" disabled="true"></mnt-tab-item>`);
+      const button = getTabItemElement(page);
+
+      // ASSERTION
+      expect(button).toHaveAttribute('disabled');
+      expect(button).toHaveClass(`${LIB_PREFIX}tab-item-disabled`);
+    });
+
+    it('SHOULD use horizontal orientation as default', async () => {
+      // SETUP
+      const page = await createTabItemComponent(`<mnt-tab-item tab-id="${DEFAULT_TAB_ID}" label="${DEFAULT_LABEL}"></mnt-tab-item>`);
+      const button = getTabItemElement(page);
+
+      // ASSERTION
+      expect(button).toHaveClass(`${LIB_PREFIX}tab-item-horizontal`);
+    });
+  });
+
+  describe('Events', () => {
+    it('SHOULD emit tabItemClick event WHEN button is clicked', async () => {
+      // SETUP
+      const page = await createTabItemComponent(`<mnt-tab-item tab-id="${DEFAULT_TAB_ID}" label="${DEFAULT_LABEL}"></mnt-tab-item>`);
+      const button = getTabItemElement(page);
+
+      const spy = jest.fn();
+      page.root.addEventListener('tabItemClick', spy);
+
+      // ACTION
+      button.click();
+
+      // ASSERTION
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: DEFAULT_TAB_ID,
+        }),
+      );
+    });
+
+    it('SHOULD NOT emit tabItemClick event WHEN disabled', async () => {
+      // SETUP
+      const page = await createTabItemComponent(`<mnt-tab-item tab-id="${DEFAULT_TAB_ID}" label="${DEFAULT_LABEL}" disabled="true"></mnt-tab-item>`);
+      const button = getTabItemElement(page);
+
+      const spy = jest.fn();
+      page.root.addEventListener('tabItemClick', spy);
+
+      // ACTION
+      button.click();
+
+      // ASSERTION
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/tab-item/tab-item.stories.ts
+++ b/src/components/tab-item/tab-item.stories.ts
@@ -1,0 +1,368 @@
+import type { Meta, StoryFn } from '@storybook/html';
+
+import { tabOrientationArray } from './tab-item.types';
+import type { TabItemProps } from './tab-item.types';
+import { HTMLString } from 'src/utils/utils';
+import { TabItem } from './tab-item';
+
+const meta: Meta<TabItemProps> = {
+  title: 'Navigation/Tab/TabItem',
+  component: 'mnt-tab-item',
+  argTypes: {
+    tabId: {
+      control: 'text',
+      description: 'Unique identifier for the tab item',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+    label: {
+      control: 'text',
+      description: 'Text label displayed in the tab',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+    icon: {
+      control: 'text',
+      description: 'Icon name to display in the tab',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'undefined' },
+      },
+    },
+    selected: {
+      control: 'boolean',
+      description: 'Whether the tab is currently selected',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the tab is disabled',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    orientation: {
+      control: 'select',
+      options: tabOrientationArray,
+      description: 'Orientation of the tab item',
+      table: {
+        defaultValue: { summary: 'horizontal' },
+        type: { summary: tabOrientationArray.join(' | ') },
+      },
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '**TabItem** é um componente individual de aba (tab) que representa uma única opção de navegação dentro de um sistema de tabs.\n\n' +
+          '### 🎯 **Características principais:**\n' +
+          '- **Elemento individual:** Representa uma única aba dentro de um grupo de navegação\n' +
+          '- **Estados visuais:** Suporte a estados selected, disabled e hover\n' +
+          '- **Ícones opcionais:** Pode exibir um ícone junto com o texto\n' +
+          '- **Orientação flexível:** Funciona tanto em layout horizontal quanto vertical\n' +
+          '- **Interatividade:** Emite eventos quando clicado (se não estiver desabilitado)\n' +
+          '- **Acessibilidade:** Suporte completo a navegação por teclado e screen readers\n\n' +
+          '### 📏 **Orientações disponíveis:**\n' +
+          '- **Horizontal:** Ideal para navegação principal em headers ou seções superiores\n' +
+          '- **Vertical:** Perfeito para sidebars, menus laterais ou navegação secundária\n\n' +
+          '### 🎨 **Estados da tab:**\n' +
+          '- **Default:** Estado normal, clicável e disponível\n' +
+          '- **Selected:** Tab atualmente selecionada (destaque visual)\n' +
+          '- **Disabled:** Tab desabilitada, não clicável\n' +
+          '- **Hover:** Estado de interação ao passar o mouse\n\n' +
+          '### 🔧 **API do componente:**\n' +
+          '- **Props:** `tabId`, `label`, `icon`, `selected`, `disabled`, `orientation`\n' +
+          '- **Eventos:** `tabItemClick` - emitido quando a tab é clicada\n' +
+          '- **Métodos:** Gerenciamento automático de estado interno\n\n' +
+          '### 💡 **Casos de uso:**\n' +
+          '- Navegação principal de aplicações\n' +
+          '- Seções de configurações\n' +
+          '- Dashboards e painéis administrativos\n' +
+          '- Formulários multi-etapas\n' +
+          '- Filtros e categorias\n\n' +
+          '**Nota:** Este componente é geralmente usado dentro de um `TabItemGroup` para formar um sistema completo de navegação por abas.\n\n' +
+          '**Figma:** [Global Assets | Tab](https://www.figma.com/design/ezr4b0ZxjmeWjASveGQoJS/-1-Core-Components?node-id=407-2410&m=dev)\n\n',
+      },
+    },
+  },
+};
+
+export default meta;
+
+const DefaultTemplate = (args: TabItemProps): HTMLString => `
+  <mnt-tab-item
+    tab-id="${args.tabId || ''}"
+    label="${args.label || ''}"
+    icon="${args.icon || ''}"
+    selected="${args.selected}"
+    disabled="${args.disabled}"
+    orientation="${args.orientation}"
+  ></mnt-tab-item>
+`;
+
+export const Default: StoryFn = DefaultTemplate.bind({});
+Default.args = {
+  tabId: 'tab-1',
+  label: 'Overview',
+  icon: 'houseSimple',
+  selected: false,
+  disabled: false,
+  orientation: 'horizontal',
+} as TabItemProps;
+
+export const WithIcon: StoryFn<typeof TabItem> = () => {
+  return DefaultTemplate({
+    tabId: 'tab-1',
+    label: 'Settings',
+    icon: 'wrench',
+    selected: true,
+    disabled: false,
+    orientation: 'horizontal',
+  });
+};
+
+WithIcon.storyName = 'With Icon';
+WithIcon.parameters = {
+  id: 'tab-item-with-icon',
+  docs: {
+    description: {
+      story: 'Tab com ícone para melhor identificação visual. O ícone é exibido junto com o texto do label.',
+    },
+  },
+  controls: { disable: true },
+};
+
+export const WithoutIcon: StoryFn<typeof TabItem> = () => {
+  return DefaultTemplate({
+    tabId: 'tab-2',
+    label: 'Profile',
+    selected: false,
+    disabled: false,
+    orientation: 'horizontal',
+  });
+};
+
+WithoutIcon.storyName = 'Without Icon';
+WithoutIcon.parameters = {
+  id: 'tab-item-without-icon',
+  docs: {
+    description: {
+      story: 'Tab sem ícone, usando apenas texto. Ideal para interfaces mais minimalistas ou quando o espaço é limitado.',
+    },
+  },
+  controls: { disable: true },
+};
+
+export const Selected: StoryFn<typeof TabItem> = () => {
+  return DefaultTemplate({
+    tabId: 'tab-3',
+    label: 'Selected Tab',
+    icon: 'bell',
+    selected: true,
+    disabled: false,
+    orientation: 'horizontal',
+  });
+};
+
+Selected.storyName = 'Selected State';
+Selected.parameters = {
+  id: 'tab-item-selected',
+  docs: {
+    description: {
+      story: 'Tab no estado selecionado. Apresenta destaque visual para indicar que é a aba ativa.',
+    },
+  },
+  controls: { disable: true },
+};
+
+export const Disabled: StoryFn<typeof TabItem> = () => {
+  return DefaultTemplate({
+    tabId: 'tab-4',
+    label: 'Disabled Tab',
+    icon: 'bell',
+    selected: false,
+    disabled: true,
+    orientation: 'horizontal',
+  });
+};
+
+Disabled.storyName = 'Disabled State';
+Disabled.parameters = {
+  id: 'tab-item-disabled',
+  docs: {
+    description: {
+      story: 'Tab no estado desabilitado. Não é clicável e tem aparência visual diferenciada para indicar indisponibilidade.',
+    },
+  },
+  controls: { disable: true },
+};
+
+export const VerticalOrientation: StoryFn<typeof TabItem> = () => {
+  return DefaultTemplate({
+    tabId: 'tab-5',
+    label: 'Vertical Tab',
+    icon: 'bell',
+    selected: false,
+    disabled: false,
+    orientation: 'vertical',
+  });
+};
+
+VerticalOrientation.storyName = 'Vertical Orientation';
+VerticalOrientation.parameters = {
+  id: 'tab-item-vertical',
+  docs: {
+    description: {
+      story: 'Tab com orientação vertical. Ideal para sidebars, menus laterais ou quando há muitas opções de navegação.',
+    },
+  },
+  controls: { disable: true },
+};
+
+export const VerticalWithIcon: StoryFn<typeof TabItem> = () => {
+  return DefaultTemplate({
+    tabId: 'tab-6',
+    label: 'Vertical with Icon',
+    icon: 'bell',
+    selected: true,
+    disabled: false,
+    orientation: 'vertical',
+  });
+};
+
+VerticalWithIcon.storyName = 'Vertical with Icon';
+VerticalWithIcon.parameters = {
+  id: 'tab-item-vertical-icon',
+  docs: {
+    description: {
+      story: 'Tab vertical com ícone. Combinação de orientação vertical com ícone para melhor identificação visual.',
+    },
+  },
+  controls: { disable: true },
+};
+
+export const AllStates: StoryFn<typeof TabItem> = () => {
+  const states: HTMLString[] = [];
+
+  // Horizontal states
+  states.push(`
+    <div class="sb-section-box">
+      <h4>Horizontal States</h4>
+      <div style="display: flex; gap: 8px; margin-bottom: 16px;">
+        ${DefaultTemplate({
+          tabId: 'tab-1',
+          label: 'Default',
+          icon: 'houseSimple',
+          selected: false,
+          disabled: false,
+          orientation: 'horizontal',
+        })}
+        ${DefaultTemplate({
+          tabId: 'tab-2',
+          label: 'Selected',
+          icon: 'wrench',
+          selected: true,
+          disabled: false,
+          orientation: 'horizontal',
+        })}
+        ${DefaultTemplate({
+          tabId: 'tab-3',
+          label: 'Disabled',
+          icon: 'starOutline',
+          selected: false,
+          disabled: true,
+          orientation: 'horizontal',
+        })}
+      </div>
+    </div>
+  `);
+
+  // Vertical states
+  states.push(`
+    <div class="sb-section-box">
+      <h4>Vertical States</h4>
+      <div style="display: flex; flex-direction: column; gap: 8px; width: 200px;">
+        ${DefaultTemplate({
+          tabId: 'tab-4',
+          label: 'Default',
+          icon: 'houseSimple',
+          selected: false,
+          disabled: false,
+          orientation: 'vertical',
+        })}
+        ${DefaultTemplate({
+          tabId: 'tab-5',
+          label: 'Selected',
+          icon: 'wrench',
+          selected: true,
+          disabled: false,
+          orientation: 'vertical',
+        })}
+        ${DefaultTemplate({
+          tabId: 'tab-6',
+          label: 'Disabled',
+          icon: 'starOutline',
+          selected: false,
+          disabled: true,
+          orientation: 'vertical',
+        })}
+      </div>
+    </div>
+  `);
+
+  // Without icons
+  states.push(`
+    <div class="sb-section-box">
+      <h4>Without Icons</h4>
+      <div style="display: flex; gap: 8px; margin-bottom: 16px;">
+        ${DefaultTemplate({
+          tabId: 'tab-7',
+          label: 'Default',
+          selected: false,
+          disabled: false,
+          orientation: 'horizontal',
+        })}
+        ${DefaultTemplate({
+          tabId: 'tab-8',
+          label: 'Selected',
+          selected: true,
+          disabled: false,
+          orientation: 'horizontal',
+        })}
+        ${DefaultTemplate({
+          tabId: 'tab-9',
+          label: 'Disabled',
+          selected: false,
+          disabled: true,
+          orientation: 'horizontal',
+        })}
+      </div>
+    </div>
+  `);
+
+  return `
+    <div>
+      ${states.join('')}
+    </div>
+  `;
+};
+
+AllStates.storyName = 'All States';
+AllStates.parameters = {
+  id: 'tab-item-all-states',
+  docs: {
+    description: {
+      story: 'Visão geral de todos os estados do componente TabItem, incluindo diferentes orientações, presença de ícones e estados de seleção/desabilitação.',
+    },
+  },
+  controls: { disable: true },
+};

--- a/src/components/tab-item/tab-item.tsx
+++ b/src/components/tab-item/tab-item.tsx
@@ -1,0 +1,69 @@
+import { Component, Host, Prop, Event, EventEmitter, h } from '@stencil/core';
+
+import { classNames, setComponentClass } from '../../utils/utils';
+import type { TabItemProps } from './tab-item.types';
+
+const COMPONENT_PREFIX = setComponentClass('tab-item');
+
+@Component({
+  tag: 'mnt-tab-item',
+  styleUrl: 'tab-item.scss',
+  shadow: false,
+})
+export class TabItem {
+  @Prop() tabId!: string;
+  @Prop() label!: string;
+  @Prop() icon?: TabItemProps['icon'];
+  @Prop() selected: boolean = false;
+  @Prop() disabled: boolean = false;
+  @Prop() orientation: TabItemProps['orientation'] = 'horizontal';
+
+  @Event() tabItemClick: EventEmitter<string>;
+
+  private handleClick(event: MouseEvent) {
+    if (this.disabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    this.tabItemClick.emit(this.tabId);
+  }
+
+  get tabItemClass() {
+    const orientationClass = setComponentClass('tab-item', this.orientation);
+    const iconClass = this.icon ? `${COMPONENT_PREFIX}-icon` : '';
+    const selectedClass = this.selected ? `${COMPONENT_PREFIX}-selected` : '';
+    const disabledClass = this.disabled ? `${COMPONENT_PREFIX}-disabled` : '';
+
+    return classNames(COMPONENT_PREFIX, orientationClass, iconClass, selectedClass, disabledClass);
+  }
+
+  private renderIcon() {
+    if (!this.icon) return null;
+
+    return (
+      <mnt-icon
+        icon={this.icon}
+        size="small"
+        class={`${COMPONENT_PREFIX}-icon`}
+      />
+    );
+  }
+
+  render() {
+    return (
+      <Host>
+        <button
+          class={this.tabItemClass}
+          disabled={this.disabled}
+          onClick={(event) => this.handleClick(event)}
+          part="tab-item"
+        >
+          {this.renderIcon()}
+          <span class={`${COMPONENT_PREFIX}-label`}>{this.label}</span>
+        </button>
+      </Host>
+    );
+  }
+}

--- a/src/components/tab-item/tab-item.types.ts
+++ b/src/components/tab-item/tab-item.types.ts
@@ -1,0 +1,16 @@
+export const componentPrefix = 'tab-item';
+
+/** Possible tab item orientations */
+export const tabOrientationArray = ['horizontal', 'vertical'] as const;
+
+/** Types derived from arrays */
+export type TabOrientation = (typeof tabOrientationArray)[number];
+
+export interface TabItemProps {
+  tabId: string;
+  label: string;
+  icon?: string;
+  selected?: boolean;
+  disabled?: boolean;
+  orientation?: TabOrientation;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -49,120 +49,165 @@
       <div id="log-content"></div>
     </div>
   </div>
-  <script>
-    const steps = [
-      {id: 'step-1', label: 'Step 1', icon: 'currencySimple', status: 'done'},
-      {id: 'step-2', label: 'Step 2', icon: 'currencySimple', status: 'active'},
-      {id: 'step-3', label: 'Step 3', icon: 'currencySimple', status: 'disabled'},
-      {id: 'step-4', label: 'Step 4', icon: 'currencySimple', status: 'disabled'},
-      {id: 'step-5', label: 'Step 5', icon: 'currencySimple', status: 'disabled'},
-    ];
 
-    const horizontalStepsElement = document.getElementById('horizontal-steps');
-    const verticalStepsElement = document.getElementById('vertical-steps');
+  <div>
+    <h2>Tab item</h2>
 
-    // Configurar steps para ambos os componentes
-    horizontalStepsElement.steps = steps;
-    verticalStepsElement.steps = steps;
+    <h3>with icon</h3>
+    <mnt-tab-item tab-id="tab-1" label="Tab 1" icon="plus" selected="true" orientation="horizontal"></mnt-tab-item>
+    <mnt-tab-item tab-id="tab-2" label="Tab 2" icon="minus" selected="false" orientation="horizontal"></mnt-tab-item>
 
-    // Adicionar listeners para eventos de clique
-    horizontalStepsElement.addEventListener('stepClick', (event) => {
-      logEvent('Horizontal Steps', event.detail);
-      // Sincronizar com o componente vertical
-      verticalStepsElement.activeStepId = event.detail.stepId;
-    });
+    <h3>without icon</h3>
+    <mnt-tab-item tab-id="tab-3" label="Tab 3" selected="false" orientation="horizontal"></mnt-tab-item>
+    <mnt-tab-item tab-id="tab-4" label="Tab 4" selected="false" orientation="horizontal"></mnt-tab-item>
+  </div>
 
-    verticalStepsElement.addEventListener('stepClick', (event) => {
-      logEvent('Vertical Steps', event.detail);
-      // Sincronizar com o componente horizontal
-      horizontalStepsElement.activeStepId = event.detail.stepId;
-    });
+  <div>
+    <h2>Tab item group - Horizontal</h2>
+    <mnt-tab-item-group id="tab-item-group-horizontal" selected-id="tab-1" orientation="horizontal"></mnt-tab-item-group>
+    <mnt-tab-item-group id="tab-item-group-horizontal-icon" selected-id="tab-1" orientation="horizontal"></mnt-tab-item-group>
+  </div>
+  <div>
+    <h2>Tab item group - Vertical</h2>
+    <mnt-tab-item-group id="tab-item-group-vertical" selected-id="tab-1" orientation="vertical"></mnt-tab-item-group>
+  </div>
+</body>
 
-    function logEvent(source, detail) {
-      const logContent = document.getElementById('log-content');
-      const timestamp = new Date().toLocaleTimeString();
-      logContent.innerHTML += `<div>[${timestamp}] ${source}: Step "${detail.step.label}" (ID: ${detail.stepId}, Index: ${detail.stepIndex})</div>`;
-      logContent.scrollTop = logContent.scrollHeight;
-    }
+<script>
+  const mockTabsIcon = [
+    { tabId: 'tab-1', label: 'Tab 1', icon: 'plus' },
+    { tabId: 'tab-2', label: 'Tab 2', icon: 'minus' },
+    { tabId: 'tab-3', label: 'Tab 3', icon: 'plus' },
+    { tabId: 'tab-4', label: 'Tab 4', icon: 'minus' },
+  ];
 
-    function handleNextStep() {
-      const currentIndex = steps.findIndex((s) => s.id === horizontalStepsElement.activeStepId);
-      if (currentIndex < steps.length - 1) {
-        // Atualiza o status do step atual para "done"
-        steps[currentIndex].status = 'done';
+  const mockTabs= [
+    { tabId: 'tab-1', label: 'Tab 1' },
+    { tabId: 'tab-2', label: 'Tab 2' },
+    { tabId: 'tab-3', label: 'Tab 3' },
+    { tabId: 'tab-4', label: 'Tab 4' },
+  ];
 
-        // Avança para o próximo step
-        const newActiveId = steps[currentIndex + 1].id;
-        horizontalStepsElement.activeStepId = newActiveId;
-        verticalStepsElement.activeStepId = newActiveId;
+  const tabItemGroupHorizontal = document.getElementById('tab-item-group-horizontal');
+  tabItemGroupHorizontal.tabs = mockTabs;
 
-        // Atualiza os steps nos componentes
-        horizontalStepsElement.steps = [...steps];
-        verticalStepsElement.steps = [...steps];
+  const tabItemGroupHorizontalIcon = document.getElementById('tab-item-group-horizontal-icon');
+  tabItemGroupHorizontalIcon.tabs = mockTabsIcon;
 
-        logEvent('Button Next', { stepId: newActiveId, stepIndex: currentIndex + 1, step: steps[currentIndex + 1] });
-      }
-    }
+  // const tabItemGroupVertical = document.getElementById('tab-item-group-vertical');
+  // tabItemGroupVertical.tabs = mockTabs;
 
-    function handlePreviousStep() {
-      const currentIndex = steps.findIndex((s) => s.id === horizontalStepsElement.activeStepId);
-      if (currentIndex > 0) {
-        const newActiveId = steps[currentIndex - 1].id;
-        horizontalStepsElement.activeStepId = newActiveId;
-        verticalStepsElement.activeStepId = newActiveId;
+  const steps = [
+    {id: 'step-1', label: 'Step 1', icon: 'currencySimple', status: 'done'},
+    {id: 'step-2', label: 'Step 2', icon: 'currencySimple', status: 'active'},
+    {id: 'step-3', label: 'Step 3', icon: 'currencySimple', status: 'disabled'},
+    {id: 'step-4', label: 'Step 4', icon: 'currencySimple', status: 'disabled'},
+    {id: 'step-5', label: 'Step 5', icon: 'currencySimple', status: 'disabled'},
+  ];
 
-        // Atualiza os steps nos componentes
-        horizontalStepsElement.steps = [...steps];
-        verticalStepsElement.steps = [...steps];
+  const horizontalStepsElement = document.getElementById('horizontal-steps');
+  const verticalStepsElement = document.getElementById('vertical-steps');
 
-        logEvent('Button Previous', { stepId: newActiveId, stepIndex: currentIndex - 1, step: steps[currentIndex - 1] });
-      }
-    }
+  // Configurar steps para ambos os componentes
+  horizontalStepsElement.steps = steps;
+  verticalStepsElement.steps = steps;
 
-    function resetSteps() {
-      // Reseta todos os steps para o estado inicial
-      steps.forEach((step, index) => {
-        if (index === 0) {
-          step.status = 'active';
-        } else {
-          step.status = 'disabled';
-        }
-      });
-      
-      horizontalStepsElement.activeStepId = 'step-1';
-      verticalStepsElement.activeStepId = 'step-1';
-      
+  // Adicionar listeners para eventos de clique
+  horizontalStepsElement.addEventListener('stepClick', (event) => {
+    logEvent('Horizontal Steps', event.detail);
+    // Sincronizar com o componente vertical
+    verticalStepsElement.activeStepId = event.detail.stepId;
+  });
+
+  verticalStepsElement.addEventListener('stepClick', (event) => {
+    logEvent('Vertical Steps', event.detail);
+    // Sincronizar com o componente horizontal
+    horizontalStepsElement.activeStepId = event.detail.stepId;
+  });
+
+  function logEvent(source, detail) {
+    const logContent = document.getElementById('log-content');
+    const timestamp = new Date().toLocaleTimeString();
+    logContent.innerHTML += `<div>[${timestamp}] ${source}: Step "${detail.step.label}" (ID: ${detail.stepId}, Index: ${detail.stepIndex})</div>`;
+    logContent.scrollTop = logContent.scrollHeight;
+  }
+
+  function handleNextStep() {
+    const currentIndex = steps.findIndex((s) => s.id === horizontalStepsElement.activeStepId);
+    if (currentIndex < steps.length - 1) {
+      // Atualiza o status do step atual para "done"
+      steps[currentIndex].status = 'done';
+
+      // Avança para o próximo step
+      const newActiveId = steps[currentIndex + 1].id;
+      horizontalStepsElement.activeStepId = newActiveId;
+      verticalStepsElement.activeStepId = newActiveId;
+
       // Atualiza os steps nos componentes
       horizontalStepsElement.steps = [...steps];
       verticalStepsElement.steps = [...steps];
-      
-      logEvent('Reset', { stepId: 'step-1', stepIndex: 0, step: steps[0] });
+
+      logEvent('Button Next', { stepId: newActiveId, stepIndex: currentIndex + 1, step: steps[currentIndex + 1] });
     }
+  }
 
-    function showState() {
-      const activeStepIndex = steps.findIndex((s) => s.id === horizontalStepsElement.activeStepId);
-      const stateContent = document.getElementById('state-content');
+  function handlePreviousStep() {
+    const currentIndex = steps.findIndex((s) => s.id === horizontalStepsElement.activeStepId);
+    if (currentIndex > 0) {
+      const newActiveId = steps[currentIndex - 1].id;
+      horizontalStepsElement.activeStepId = newActiveId;
+      verticalStepsElement.activeStepId = newActiveId;
 
-      let stateInfo = `Active Step: ${horizontalStepsElement.activeStepId} (index: ${activeStepIndex})\n`;
-      stateInfo += `Max Accessed Index (Horizontal): ${horizontalStepsElement.getAttribute('data-max-accessed-index') || 'N/A'}\n`;
-      stateInfo += `Max Accessed Index (Vertical): ${verticalStepsElement.getAttribute('data-max-accessed-index') || 'N/A'}\n`;
-      stateInfo += `Is First Step: ${activeStepIndex === 0}\n`;
-      stateInfo += `Is Last Step: ${activeStepIndex === steps.length - 1}\n\n`;
-      stateInfo += 'Step States:\n';
+      // Atualiza os steps nos componentes
+      horizontalStepsElement.steps = [...steps];
+      verticalStepsElement.steps = [...steps];
 
-      steps.forEach((step, index) => {
-        const isActive = index === activeStepIndex;
-        const horizontalMaxIndex = parseInt(horizontalStepsElement.getAttribute('data-max-accessed-index') || '0');
-        const verticalMaxIndex = parseInt(verticalStepsElement.getAttribute('data-max-accessed-index') || '0');
-        const maxIndex = Math.max(horizontalMaxIndex, verticalMaxIndex);
-        const isDisabled = index > maxIndex;
-        const status = isActive ? 'ACTIVE' : isDisabled ? 'DISABLED' : 'CLICKABLE';
-        stateInfo += `  ${step.label}: ${status}\n`;
-      });
-
-      stateContent.textContent = stateInfo;
+      logEvent('Button Previous', { stepId: newActiveId, stepIndex: currentIndex - 1, step: steps[currentIndex - 1] });
     }
-  </script>
-</body>
+  }
 
+  function resetSteps() {
+    // Reseta todos os steps para o estado inicial
+    steps.forEach((step, index) => {
+      if (index === 0) {
+        step.status = 'active';
+      } else {
+        step.status = 'disabled';
+      }
+    });
+    
+    horizontalStepsElement.activeStepId = 'step-1';
+    verticalStepsElement.activeStepId = 'step-1';
+    
+    // Atualiza os steps nos componentes
+    horizontalStepsElement.steps = [...steps];
+    verticalStepsElement.steps = [...steps];
+    
+    logEvent('Reset', { stepId: 'step-1', stepIndex: 0, step: steps[0] });
+  }
+
+  function showState() {
+    const activeStepIndex = steps.findIndex((s) => s.id === horizontalStepsElement.activeStepId);
+    const stateContent = document.getElementById('state-content');
+
+    let stateInfo = `Active Step: ${horizontalStepsElement.activeStepId} (index: ${activeStepIndex})\n`;
+    stateInfo += `Max Accessed Index (Horizontal): ${horizontalStepsElement.getAttribute('data-max-accessed-index') || 'N/A'}\n`;
+    stateInfo += `Max Accessed Index (Vertical): ${verticalStepsElement.getAttribute('data-max-accessed-index') || 'N/A'}\n`;
+    stateInfo += `Is First Step: ${activeStepIndex === 0}\n`;
+    stateInfo += `Is Last Step: ${activeStepIndex === steps.length - 1}\n\n`;
+    stateInfo += 'Step States:\n';
+
+    steps.forEach((step, index) => {
+      const isActive = index === activeStepIndex;
+      const horizontalMaxIndex = parseInt(horizontalStepsElement.getAttribute('data-max-accessed-index') || '0');
+      const verticalMaxIndex = parseInt(verticalStepsElement.getAttribute('data-max-accessed-index') || '0');
+      const maxIndex = Math.max(horizontalMaxIndex, verticalMaxIndex);
+      const isDisabled = index > maxIndex;
+      const status = isActive ? 'ACTIVE' : isDisabled ? 'DISABLED' : 'CLICKABLE';
+      stateInfo += `  ${step.label}: ${status}\n`;
+    });
+
+    stateContent.textContent = stateInfo;
+  }
+</script>
 </html>


### PR DESCRIPTION
## Description
Add tab navigation system with tab-item and tab-item-group components

- Add horizontal and vertical orientation support
- Add optional icon support for each tab
- Add controlled and automatic selection state management
- Add tabChange event emission
- Add visual states: default, hover, selected, disabled
- Add comprehensive Storybook documentation with interactive examples
- Add support for disabled tabs and different use cases

## Figma
https://www.figma.com/design/ezr4b0ZxjmeWjASveGQoJS/-1-Core-Components?node-id=521-2811&m=dev