### PR TITLE
feat(date-picker): create component

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,8 @@
     "tab",
     "steps",
     "icon-large",
-    "switch"
+    "switch",
+    "date-picker"
   ],
   // Opcional: desabilite o auto-run se preferir rodar só manualmente
   // "jest.autoRun": false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ Todas as mudanças notáveis deste projeto serão documentadas neste arquivo.
 
 Este projeto segue o [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/) e [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [2.9.2] – 2025-12-26
+
+### 🚀 Adicionado
+
+- **DatePicker**: Novo componente de seleção de datas
+  - Modo single: Seleção de data única
+  - Modo range: Seleção de intervalo/período entre duas datas
+  - Propriedade `disablePastDates`: Desabilita seleção de datas anteriores ao dia atual
+  - Integração nativa com formulários HTML via `formAssociated`
+  - Validação integrada com suporte a `required` e custom validity
+  - Eventos customizados: `date-selected`, `cancel`, `month-change`
+  - Internacionalização: Suporte a diferentes locales (pt-BR, en-US, etc.)
+  - Acessibilidade: ARIA attributes e navegação via teclado
+  - Configurações: `minDate`, `maxDate`, `firstDayOfWeek`, `initialMonth`
+  - Distinção visual entre início e fim do range (modo range)
+  - Calendário dinâmico: Exibe apenas semanas do mês atual/necessárias
+  - Documentação completa e exemplos no Storybook
+  - Exemplos práticos no `index.html`
+
+### ✨ Melhorado
+
+- **Switch**: Renomeação de eventos para seguir padrão Stencil
+  - Eventos renomeados de `onChange`, `onBlur`, `onFocus` para `mntChange`, `mntBlur`, `mntFocus`
+  - Eliminação de warnings do Stencil sobre conflitos com eventos nativos do DOM
+  - Mantém compatibilidade com eventos nativos via `dispatchEvent`
+  - Documentação e testes atualizados
+
+### 🗑️ Removido
+
+- **DatePicker**: Propriedade `showWeekNumbers` removida
+  - Propriedade estava definida mas não implementada
+  - Removida para evitar confusão e manter API limpa
+
 ## [2.9.1] – 2025-12-17
 
 ### 🐛 Correções

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yooga-tecnologia/mantra",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "Biblioteca de componentes web desenvolvida com StencilJS para criar interfaces reutilizáveis e performáticas em diferentes frameworks e projetos.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,6 +8,7 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { BadgeBaseProps } from "./components/badge/badge.types";
 import { BrandProps } from "./components/brand/brand.types";
 import { ButtonIconProps, ButtonProps } from "./components/button/button.types";
+import { DatePickerMode, DateRange, DateSelectedEventDetail, MonthYear } from "./components/date-picker/date-picker.types";
 import { FieldNumberVariant } from "./components/field-number/field-number.types";
 import { SizeVariants } from "./shared/theme/theme.types";
 import { FieldTextProps } from "./components/field-text/field-text.types";
@@ -21,6 +22,7 @@ import { TooltipProps } from "./components/tooltip/tooltip.types";
 export { BadgeBaseProps } from "./components/badge/badge.types";
 export { BrandProps } from "./components/brand/brand.types";
 export { ButtonIconProps, ButtonProps } from "./components/button/button.types";
+export { DatePickerMode, DateRange, DateSelectedEventDetail, MonthYear } from "./components/date-picker/date-picker.types";
 export { FieldNumberVariant } from "./components/field-number/field-number.types";
 export { SizeVariants } from "./shared/theme/theme.types";
 export { FieldTextProps } from "./components/field-text/field-text.types";
@@ -61,6 +63,20 @@ export namespace Components {
         "icon"?: ButtonIconProps['icon'];
         "size": ButtonIconProps['size'];
         "variant": ButtonIconProps['variant'];
+    }
+    interface MntDatePicker {
+        "disablePastDates"?: boolean;
+        "disabled"?: boolean;
+        "firstDayOfWeek"?: number;
+        "initialMonth"?: Date | string | null;
+        "locale"?: string;
+        "maxDate"?: Date | string | null;
+        "minDate"?: Date | string | null;
+        "mode"?: DatePickerMode;
+        "placeholder"?: string;
+        "required"?: boolean;
+        "selectedDate"?: Date | string | null;
+        "selectedRange"?: DateRange | null;
     }
     interface MntFieldNumber {
         "disabled"?: boolean;
@@ -154,6 +170,10 @@ export interface MntButtonIconCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLMntButtonIconElement;
 }
+export interface MntDatePickerCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLMntDatePickerElement;
+}
 export interface MntFieldTextCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLMntFieldTextElement;
@@ -220,6 +240,25 @@ declare global {
     var HTMLMntButtonIconElement: {
         prototype: HTMLMntButtonIconElement;
         new (): HTMLMntButtonIconElement;
+    };
+    interface HTMLMntDatePickerElementEventMap {
+        "datePickerSelected": DateSelectedEventDetail;
+        "datePickerCancel": void;
+        "datePickerMonthChange": MonthYear;
+    }
+    interface HTMLMntDatePickerElement extends Components.MntDatePicker, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLMntDatePickerElementEventMap>(type: K, listener: (this: HTMLMntDatePickerElement, ev: MntDatePickerCustomEvent<HTMLMntDatePickerElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLMntDatePickerElementEventMap>(type: K, listener: (this: HTMLMntDatePickerElement, ev: MntDatePickerCustomEvent<HTMLMntDatePickerElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLMntDatePickerElement: {
+        prototype: HTMLMntDatePickerElement;
+        new (): HTMLMntDatePickerElement;
     };
     interface HTMLMntFieldNumberElement extends Components.MntFieldNumber, HTMLStencilElement {
     }
@@ -344,6 +383,7 @@ declare global {
         "mnt-brand": HTMLMntBrandElement;
         "mnt-button": HTMLMntButtonElement;
         "mnt-button-icon": HTMLMntButtonIconElement;
+        "mnt-date-picker": HTMLMntDatePickerElement;
         "mnt-field-number": HTMLMntFieldNumberElement;
         "mnt-field-text": HTMLMntFieldTextElement;
         "mnt-icon": HTMLMntIconElement;
@@ -388,6 +428,23 @@ declare namespace LocalJSX {
         "onButtonClick"?: (event: MntButtonIconCustomEvent<MouseEvent>) => void;
         "size"?: ButtonIconProps['size'];
         "variant"?: ButtonIconProps['variant'];
+    }
+    interface MntDatePicker {
+        "disablePastDates"?: boolean;
+        "disabled"?: boolean;
+        "firstDayOfWeek"?: number;
+        "initialMonth"?: Date | string | null;
+        "locale"?: string;
+        "maxDate"?: Date | string | null;
+        "minDate"?: Date | string | null;
+        "mode"?: DatePickerMode;
+        "onDatePickerCancel"?: (event: MntDatePickerCustomEvent<void>) => void;
+        "onDatePickerMonthChange"?: (event: MntDatePickerCustomEvent<MonthYear>) => void;
+        "onDatePickerSelected"?: (event: MntDatePickerCustomEvent<DateSelectedEventDetail>) => void;
+        "placeholder"?: string;
+        "required"?: boolean;
+        "selectedDate"?: Date | string | null;
+        "selectedRange"?: DateRange | null;
     }
     interface MntFieldNumber {
         "disabled"?: boolean;
@@ -488,6 +545,7 @@ declare namespace LocalJSX {
         "mnt-brand": MntBrand;
         "mnt-button": MntButton;
         "mnt-button-icon": MntButtonIcon;
+        "mnt-date-picker": MntDatePicker;
         "mnt-field-number": MntFieldNumber;
         "mnt-field-text": MntFieldText;
         "mnt-icon": MntIcon;
@@ -508,6 +566,7 @@ declare module "@stencil/core" {
             "mnt-brand": LocalJSX.MntBrand & JSXBase.HTMLAttributes<HTMLMntBrandElement>;
             "mnt-button": LocalJSX.MntButton & JSXBase.HTMLAttributes<HTMLMntButtonElement>;
             "mnt-button-icon": LocalJSX.MntButtonIcon & JSXBase.HTMLAttributes<HTMLMntButtonIconElement>;
+            "mnt-date-picker": LocalJSX.MntDatePicker & JSXBase.HTMLAttributes<HTMLMntDatePickerElement>;
             "mnt-field-number": LocalJSX.MntFieldNumber & JSXBase.HTMLAttributes<HTMLMntFieldNumberElement>;
             "mnt-field-text": LocalJSX.MntFieldText & JSXBase.HTMLAttributes<HTMLMntFieldTextElement>;
             "mnt-icon": LocalJSX.MntIcon & JSXBase.HTMLAttributes<HTMLMntIconElement>;

--- a/src/components/date-picker/README.md
+++ b/src/components/date-picker/README.md
@@ -1,0 +1,147 @@
+# mnt-date-picker
+
+Componente de seleção de datas com suporte a modo single (data única) e range (intervalo de datas).
+
+## Uso Básico
+
+```html
+<!-- Modo Single -->
+<mnt-date-picker
+  mode="single"
+  (onDateSelected)="handleDateSelected($event)"
+></mnt-date-picker>
+
+<!-- Modo Range -->
+<mnt-date-picker
+  mode="range"
+  (onDateSelected)="handleRangeSelected($event)"
+></mnt-date-picker>
+```
+
+## Angular
+
+```typescript
+// Template
+<mnt-date-picker
+  [mode]="'single'"
+  [selectedDate]="selectedDate"
+  [minDate]="minDate"
+  (onDateSelected)="handleDateSelected($event)"
+  (onCancel)="handleCancel()"
+></mnt-date-picker>
+
+// Component
+export class MyComponent {
+  selectedDate: Date | null = null;
+  minDate = new Date();
+
+  handleDateSelected(event: any): void {
+    console.log('Data selecionada:', event.detail.date);
+    console.log('Formatada:', event.detail.formattedDate);
+    this.selectedDate = event.detail.date;
+  }
+
+  handleCancel(): void {
+    console.log('Seleção cancelada');
+  }
+}
+```
+
+## Eventos
+
+- `onDateSelected`: Emitido quando uma data (ou range) é selecionada
+- `onCancel`: Emitido quando o usuário cancela a seleção
+- `onMonthChange`: Emitido quando o usuário navega entre meses
+
+## Métodos Públicos
+
+- `getSelectedDate()`: Retorna a data ou range selecionado
+- `setSelectedDate(date)`: Define a data selecionada (modo single)
+- `setSelectedRange(range)`: Define o range selecionado (modo range)
+- `clearSelection()`: Limpa a seleção
+
+## Props
+
+| Prop | Tipo | Padrão | Descrição |
+|------|------|--------|-----------|
+| `mode` | `'single' \| 'range'` | `'single'` | Modo de seleção |
+| `selectedDate` | `Date \| string` | `null` | Data selecionada (modo single) |
+| `selectedRange` | `DateRange` | `null` | Range selecionado (modo range) |
+| `minDate` | `Date \| string` | `null` | Data mínima selecionável |
+| `maxDate` | `Date \| string` | `null` | Data máxima selecionável |
+| `locale` | `string` | `'pt-BR'` | Locale para formatação |
+| `disabled` | `boolean` | `false` | Se está desabilitado |
+| `required` | `boolean` | `false` | Se é obrigatório |
+| `disablePastDates` | `boolean` | `false` | Desabilita seleção de datas passadas |
+
+## Exemplos Práticos
+
+### Desabilitar Datas Passadas
+
+```html
+<!-- Ideal para agendamentos e reservas -->
+<mnt-date-picker
+  mode="single"
+  disable-past-dates
+  (onDateSelected)="handleDateSelected($event)"
+></mnt-date-picker>
+```
+
+### Range com Data Mínima
+
+```html
+<!-- Período a partir de hoje -->
+<mnt-date-picker
+  mode="range"
+  disable-past-dates
+  (onDateSelected)="handleRangeSelected($event)"
+></mnt-date-picker>
+```
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property           | Attribute            | Description | Type                  | Default     |
+| ------------------ | -------------------- | ----------- | --------------------- | ----------- |
+| `disablePastDates` | `disable-past-dates` |             | `boolean`             | `false`     |
+| `disabled`         | `disabled`           |             | `boolean`             | `false`     |
+| `firstDayOfWeek`   | `first-day-of-week`  |             | `number`              | `0`         |
+| `initialMonth`     | `initial-month`      |             | `Date \| string`      | `null`      |
+| `locale`           | `locale`             |             | `string`              | `'pt-BR'`   |
+| `maxDate`          | `max-date`           |             | `Date \| string`      | `null`      |
+| `minDate`          | `min-date`           |             | `Date \| string`      | `null`      |
+| `mode`             | `mode`               |             | `"range" \| "single"` | `'single'`  |
+| `placeholder`      | `placeholder`        |             | `string`              | `undefined` |
+| `required`         | `required`           |             | `boolean`             | `false`     |
+| `selectedDate`     | `selected-date`      |             | `Date \| string`      | `null`      |
+| `selectedRange`    | --                   |             | `DateRange`           | `null`      |
+
+
+## Events
+
+| Event                   | Description | Type                                   |
+| ----------------------- | ----------- | -------------------------------------- |
+| `datePickerCancel`      |             | `CustomEvent<void>`                    |
+| `datePickerMonthChange` |             | `CustomEvent<MonthYear>`               |
+| `datePickerSelected`    |             | `CustomEvent<DateSelectedEventDetail>` |
+
+
+## Dependencies
+
+### Depends on
+
+- [mnt-button-icon](../button)
+
+### Graph
+```mermaid
+graph TD;
+  mnt-date-picker --> mnt-button-icon
+  mnt-button-icon --> mnt-icon
+  style mnt-date-picker fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/date-picker/date-picker.scss
+++ b/src/components/date-picker/date-picker.scss
@@ -1,0 +1,12 @@
+/**
+  * This file is a barrel file for the styles of the <mnt-badge> component.
+  *
+  * WARNING: Please do not add any CSS rules directly to this file!
+  * Check [index.scss](./styles/index.scss) to know how to organize component's stylesheets
+  **/
+
+@use '../../shared/theme/core/theme' as theme;
+@use '../../shared/theme/core/typography' as typography;
+@use '../../shared/theme/tokens/_sizing' as sizing;
+
+@forward './styles/index.scss';

--- a/src/components/date-picker/date-picker.spec.tsx
+++ b/src/components/date-picker/date-picker.spec.tsx
@@ -1,0 +1,364 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { DatePicker } from './date-picker';
+
+describe('<mnt-date-picker>', () => {
+  describe('Rendering', () => {
+    it('SHOULD render correctly WHEN has default props', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker></mnt-date-picker>',
+      });
+
+      expect(page.root).toBeTruthy();
+      expect(page.root.querySelector('.mnt-date-picker')).toBeTruthy();
+    });
+
+    it('SHOULD render in single mode by default', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker></mnt-date-picker>',
+      });
+
+      const component = page.rootInstance as DatePicker;
+      expect(component.mode).toBe('single');
+    });
+
+    it('SHOULD render in range mode WHEN mode is range', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker mode="range"></mnt-date-picker>',
+      });
+
+      const component = page.rootInstance as DatePicker;
+      expect(component.mode).toBe('range');
+    });
+  });
+
+  describe('Props and Attributes', () => {
+    it('SHOULD apply locale correctly', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker locale="en-US"></mnt-date-picker>',
+      });
+
+      const component = page.rootInstance as DatePicker;
+      expect(component.locale).toBe('en-US');
+    });
+
+    it('SHOULD be disabled WHEN disabled prop is true', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker disabled></mnt-date-picker>',
+      });
+
+      const component = page.rootInstance as DatePicker;
+      expect(component.disabled).toBe(true);
+    });
+
+    it('SHOULD be required WHEN required prop is true', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker required></mnt-date-picker>',
+      });
+
+      const component = page.rootInstance as DatePicker;
+      expect(component.required).toBe(true);
+    });
+  });
+
+  describe('Behavior - Single Mode', () => {
+    it('SHOULD emit datePickerSelected event WHEN date is clicked in single mode', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker mode="single"></mnt-date-picker>',
+      });
+
+      const dateSelectedHandler = jest.fn();
+      page.root.addEventListener('datePickerSelected', dateSelectedHandler);
+
+      const component = page.rootInstance as DatePicker;
+      const today = new Date();
+
+      // Simulate date click
+      await component['handleDateClick'](today);
+      await page.waitForChanges();
+
+      expect(dateSelectedHandler).toHaveBeenCalledTimes(1);
+      expect(dateSelectedHandler.mock.calls[0][0].detail.mode).toBe('single');
+      expect(dateSelectedHandler.mock.calls[0][0].detail.date).toBeDefined();
+    });
+
+    it('SHOULD update selected date WHEN date is clicked', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker mode="single"></mnt-date-picker>',
+      });
+
+      const component = page.rootInstance as DatePicker;
+      const today = new Date();
+
+      await component['handleDateClick'](today);
+      await page.waitForChanges();
+
+      const selectedDate = component.getSelectedDate() as Date;
+      expect(selectedDate).toBeDefined();
+      expect(selectedDate.getDate()).toBe(today.getDate());
+    });
+  });
+
+  describe('Behavior - Range Mode', () => {
+    it('SHOULD select start date on first click in range mode', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker mode="range"></mnt-date-picker>',
+      });
+
+      const component = page.rootInstance as DatePicker;
+      const startDate = new Date(2024, 0, 15);
+
+      await component['handleDateClick'](startDate);
+      await page.waitForChanges();
+
+      const range = component.getSelectedDate() as any;
+      expect(range.start).toBeDefined();
+      expect(range.end).toBeNull();
+    });
+
+    it('SHOULD complete range on second click', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker mode="range"></mnt-date-picker>',
+      });
+
+      const component = page.rootInstance as DatePicker;
+      const startDate = new Date(2024, 0, 15);
+      const endDate = new Date(2024, 0, 20);
+
+      await component['handleDateClick'](startDate);
+      await page.waitForChanges();
+
+      await component['handleDateClick'](endDate);
+      await page.waitForChanges();
+
+      const range = component.getSelectedDate() as any;
+      expect(range.start).toBeDefined();
+      expect(range.end).toBeDefined();
+    });
+
+    it('SHOULD emit onDateSelected with range WHEN range is completed', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker mode="range"></mnt-date-picker>',
+      });
+
+      const dateSelectedHandler = jest.fn();
+      page.root.addEventListener('datePickerSelected', dateSelectedHandler);
+
+      const component = page.rootInstance as DatePicker;
+      const startDate = new Date(2024, 0, 15);
+      const endDate = new Date(2024, 0, 20);
+
+      await component['handleDateClick'](startDate);
+      await component['handleDateClick'](endDate);
+      await page.waitForChanges();
+
+      expect(dateSelectedHandler).toHaveBeenCalledTimes(2);
+      const lastCall = dateSelectedHandler.mock.calls[1][0];
+      expect(lastCall.detail.mode).toBe('range');
+      expect(lastCall.detail.range).toBeDefined();
+      expect(lastCall.detail.range.start).toBeDefined();
+      expect(lastCall.detail.range.end).toBeDefined();
+    });
+  });
+
+  describe('Public Methods', () => {
+    it('SHOULD return selected date WHEN getSelectedDate is called', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker mode="single"></mnt-date-picker>',
+      });
+
+      const component = page.rootInstance as DatePicker;
+      const today = new Date();
+
+      await component['handleDateClick'](today);
+      await page.waitForChanges();
+
+      const selectedDate = component.getSelectedDate();
+      expect(selectedDate).toBeDefined();
+    });
+
+    it('SHOULD set selected date WHEN setSelectedDate is called', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker mode="single"></mnt-date-picker>',
+      });
+
+      const component = page.rootInstance as DatePicker;
+      const testDate = new Date(2024, 5, 15);
+
+      component.setSelectedDate(testDate);
+      await page.waitForChanges();
+
+      expect(component.selectedDate).toBeDefined();
+    });
+
+    it('SHOULD clear selection WHEN clearSelection is called', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker mode="single"></mnt-date-picker>',
+      });
+
+      const component = page.rootInstance as DatePicker;
+      const today = new Date();
+
+      await component['handleDateClick'](today);
+      await page.waitForChanges();
+
+      component.clearSelection();
+      await page.waitForChanges();
+
+      const selectedDate = component.getSelectedDate();
+      expect(selectedDate).toBeNull();
+    });
+  });
+
+  describe('Navigation', () => {
+    it('SHOULD navigate to previous month', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker></mnt-date-picker>',
+      });
+
+      const component = page.rootInstance as DatePicker;
+      const initialMonth = component['currentMonth'].month;
+
+      await component['previousMonth']();
+      await page.waitForChanges();
+
+      const newMonth = component['currentMonth'].month;
+      expect(newMonth).not.toBe(initialMonth);
+    });
+
+    it('SHOULD navigate to next month', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker></mnt-date-picker>',
+      });
+
+      const component = page.rootInstance as DatePicker;
+      const initialMonth = component['currentMonth'].month;
+
+      await component['nextMonth']();
+      await page.waitForChanges();
+
+      const newMonth = component['currentMonth'].month;
+      expect(newMonth).not.toBe(initialMonth);
+    });
+
+    it('SHOULD emit datePickerMonthChange WHEN month changes', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker></mnt-date-picker>',
+      });
+
+      const monthChangeHandler = jest.fn();
+      page.root.addEventListener('datePickerMonthChange', monthChangeHandler);
+
+      const component = page.rootInstance as DatePicker;
+      await component['nextMonth']();
+      await page.waitForChanges();
+
+      expect(monthChangeHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Events', () => {
+    it('SHOULD emit datePickerCancel event WHEN cancel button is clicked', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker></mnt-date-picker>',
+      });
+
+      const cancelHandler = jest.fn();
+      page.root.addEventListener('datePickerCancel', cancelHandler);
+
+      const component = page.rootInstance as DatePicker;
+      await component['handleCancel']();
+      await page.waitForChanges();
+
+      expect(cancelHandler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Date Restrictions', () => {
+    it('SHOULD not allow selection of dates before minDate', async () => {
+      const minDate = new Date(2024, 5, 15);
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: `<mnt-date-picker min-date="${minDate.toISOString()}"></mnt-date-picker>`,
+      });
+
+      const component = page.rootInstance as DatePicker;
+      const beforeMinDate = new Date(2024, 5, 10);
+
+      const isSelectable = component['isDateSelectable'](beforeMinDate);
+      expect(isSelectable).toBe(false);
+    });
+
+    it('SHOULD not allow selection of dates after maxDate', async () => {
+      const maxDate = new Date(2024, 5, 15);
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: `<mnt-date-picker max-date="${maxDate.toISOString()}"></mnt-date-picker>`,
+      });
+
+      const component = page.rootInstance as DatePicker;
+      const afterMaxDate = new Date(2024, 5, 20);
+
+      const isSelectable = component['isDateSelectable'](afterMaxDate);
+      expect(isSelectable).toBe(false);
+    });
+
+    it('SHOULD not allow selection of past dates WHEN disablePastDates is true', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker disable-past-dates></mnt-date-picker>',
+      });
+
+      const component = page.rootInstance as DatePicker;
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+
+      const isSelectable = component['isDateSelectable'](yesterday);
+      expect(isSelectable).toBe(false);
+    });
+
+    it('SHOULD allow selection of today WHEN disablePastDates is true', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker disable-past-dates></mnt-date-picker>',
+      });
+
+      const component = page.rootInstance as DatePicker;
+      const today = new Date();
+
+      const isSelectable = component['isDateSelectable'](today);
+      expect(isSelectable).toBe(true);
+    });
+
+    it('SHOULD allow selection of future dates WHEN disablePastDates is true', async () => {
+      const page = await newSpecPage({
+        components: [DatePicker],
+        html: '<mnt-date-picker disable-past-dates></mnt-date-picker>',
+      });
+
+      const component = page.rootInstance as DatePicker;
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+
+      const isSelectable = component['isDateSelectable'](tomorrow);
+      expect(isSelectable).toBe(true);
+    });
+  });
+});

--- a/src/components/date-picker/date-picker.stories.ts
+++ b/src/components/date-picker/date-picker.stories.ts
@@ -1,0 +1,375 @@
+import type { Meta, StoryFn } from '@storybook/html';
+import { HTMLString } from 'src/utils/utils';
+import { DatePickerBaseProps } from './date-picker.types';
+
+const meta: Meta<DatePickerBaseProps> = {
+  title: 'Forms/DatePicker',
+  component: 'mnt-date-picker',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '**DatePicker** é o componente de seleção de datas que permite escolher uma data única ou um intervalo de datas.\n\n' +
+          '### 🎯 **Características principais:**\n' +
+          '- **Dual mode:** Suporta seleção única (single) ou intervalo (range)\n' +
+          '- **Integração nativa:** Participação automática em formulários HTML\n' +
+          '- **Validação integrada:** Suporte a required e custom validity via ElementInternals\n' +
+          '- **Eventos customizados:** Emite eventos detalhados para integração com frameworks\n' +
+          '- **Acessibilidade completa:** ARIA attributes, navegação via teclado\n' +
+          '- **Internacionalização:** Suporte a diferentes locales (pt-BR, en-US, etc.)\n\n' +
+          '### 🎨 **Funcionalidades:**\n' +
+          '- **Modo Single:** Seleção de uma única data\n' +
+          '- **Modo Range:** Seleção de intervalo entre duas datas\n' +
+          '- **Min/Max Date:** Restrição de datas selecionáveis\n' +
+          '- **Navegação de meses:** Controles para navegar entre meses/anos\n' +
+          '- **Data atual destacada:** Indicação visual da data de hoje\n' +
+          '- **Formatação customizada:** Suporta diferentes formatos de data por locale\n\n' +
+          '### 📋 **Casos de uso:**\n' +
+          '- Seleção de data de nascimento\n' +
+          '- Agendamento de eventos\n' +
+          '- Filtros de período (data início/fim)\n' +
+          '- Reservas e disponibilidade\n' +
+          '- Relatórios com intervalo de datas\n\n' +
+          '### 🔌 **Integração Angular:**\n' +
+          'Use diretamente com eventos `(datePickerSelected)` e binding `[selectedDate]`.\n' +
+          'Sem necessidade de wrappers complexos!\n\n' +
+          'Para ver exemplos de integração, consulte FRAMEWORK_INTEGRATION.md.\n\n',
+      },
+    },
+  },
+  argTypes: {
+    mode: {
+      control: 'select',
+      options: ['single', 'range'],
+      description: 'Mode of date selection',
+      table: {
+        defaultValue: { summary: 'single' },
+        type: { summary: 'single | range' },
+      },
+    },
+    locale: {
+      control: 'select',
+      options: ['pt-BR', 'en-US', 'es-ES', 'fr-FR'],
+      description: 'Locale for date formatting',
+      table: {
+        defaultValue: { summary: 'pt-BR' },
+        type: { summary: 'string' },
+      },
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the date picker is disabled',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+    required: {
+      control: 'boolean',
+      description: 'Whether the date picker is required for form validation',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+    firstDayOfWeek: {
+      control: 'select',
+      options: [0, 1, 6],
+      description: 'First day of the week (0=Sunday, 1=Monday, 6=Saturday)',
+      table: {
+        defaultValue: { summary: '0' },
+        type: { summary: 'number' },
+      },
+    },
+    disablePastDates: {
+      control: 'boolean',
+      description: 'Disables selection of dates before today',
+      table: {
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+  },
+};
+
+export default meta;
+
+const DefaultTemplate = (args: Partial<DatePickerBaseProps>): HTMLString => `
+  <div style="display: flex; justify-content: center; padding: 40px;">
+    <mnt-date-picker
+      mode="${args.mode || 'single'}"
+      ${args.locale ? `locale="${args.locale}"` : ''}
+      ${args.disabled ? 'disabled' : ''}
+      ${args.required ? 'required' : ''}
+      ${args.firstDayOfWeek !== undefined ? `first-day-of-week="${args.firstDayOfWeek}"` : ''}
+      ${args.disablePastDates ? 'disable-past-dates' : ''}
+    ></mnt-date-picker>
+  </div>
+`;
+
+export const SingleMode = DefaultTemplate.bind({});
+SingleMode.args = {
+  mode: 'single',
+  locale: 'pt-BR',
+} as Partial<DatePickerBaseProps>;
+SingleMode.parameters = {
+  docs: {
+    description: {
+      story: 'Modo de seleção única (single). ' + 'Permite selecionar apenas uma data por vez. ' + 'Ideal para data de nascimento, vencimentos, agendamentos únicos.',
+    },
+  },
+};
+
+export const RangeMode = DefaultTemplate.bind({});
+RangeMode.args = {
+  mode: 'range',
+  locale: 'pt-BR',
+} as Partial<DatePickerBaseProps>;
+RangeMode.parameters = {
+  docs: {
+    description: {
+      story:
+        'Modo de seleção de intervalo (range). ' +
+        'Permite selecionar uma data inicial e uma data final. ' +
+        'Clique na primeira data e depois na segunda para definir o período. ' +
+        'Ideal para filtros de relatórios, reservas, períodos de disponibilidade.',
+    },
+  },
+};
+
+export const DifferentLocales: StoryFn = (): HTMLString => {
+  return `
+    <div style="padding: 20px;">
+      <h3>Diferentes Locales</h3>
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 24px; margin-top: 20px;">
+        <div>
+          <h4 style="margin-bottom: 12px;">Português (pt-BR)</h4>
+          <mnt-date-picker locale="pt-BR"></mnt-date-picker>
+        </div>
+
+        <div>
+          <h4 style="margin-bottom: 12px;">English (en-US)</h4>
+          <mnt-date-picker locale="en-US"></mnt-date-picker>
+        </div>
+
+        <div>
+          <h4 style="margin-bottom: 12px;">Español (es-ES)</h4>
+          <mnt-date-picker locale="es-ES"></mnt-date-picker>
+        </div>
+
+        <div>
+          <h4 style="margin-bottom: 12px;">Français (fr-FR)</h4>
+          <mnt-date-picker locale="fr-FR"></mnt-date-picker>
+        </div>
+      </div>
+    </div>
+  `;
+};
+
+DifferentLocales.parameters = {
+  controls: { disable: true },
+  docs: {
+    description: {
+      story: 'Demonstração de diferentes locales suportados. ' + 'O componente automaticamente formata datas, nomes de meses e dias da semana de acordo com o locale especificado.',
+    },
+  },
+};
+
+export const WithMinMaxDates: StoryFn = (): HTMLString => {
+  const today = new Date();
+  const minDate = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const maxDate = new Date(today.getFullYear(), today.getMonth() + 3, today.getDate());
+
+  return `
+    <div style="display: flex; justify-content: center; padding: 40px; flex-direction: column; align-items: center;">
+      <div style="margin-bottom: 20px; text-align: center;">
+        <h3>Date Picker com Restrições</h3>
+        <p style="color: #666;">Apenas datas dos próximos 3 meses são selecionáveis</p>
+      </div>
+      <mnt-date-picker
+        min-date="${minDate.toISOString()}"
+        max-date="${maxDate.toISOString()}"
+      ></mnt-date-picker>
+    </div>
+  `;
+};
+
+WithMinMaxDates.parameters = {
+  controls: { disable: true },
+  docs: {
+    description: {
+      story:
+        'Exemplo com restrições de min-date e max-date. ' +
+        'Datas fora do intervalo permitido aparecem desabilitadas e não são selecionáveis. ' +
+        'Útil para reservas, agendamentos com disponibilidade limitada.',
+    },
+  },
+};
+
+export const IntegrationExample: StoryFn = (): HTMLString => {
+  return `
+    <div style="padding: 20px; max-width: 800px; margin: 0 auto;">
+      <h3>Exemplo de Integração com Eventos</h3>
+
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-top: 20px;">
+        <!-- Single Mode -->
+        <div>
+          <h4>Modo Single</h4>
+          <mnt-date-picker
+            id="single-picker"
+            mode="single"
+          ></mnt-date-picker>
+          <div id="single-output" style="margin-top: 16px; padding: 12px; background: #f5f5f5; border-radius: 4px; min-height: 60px;">
+            <strong>Data Selecionada:</strong>
+            <div id="single-date">Nenhuma</div>
+          </div>
+        </div>
+
+        <!-- Range Mode -->
+        <div>
+          <h4>Modo Range</h4>
+          <mnt-date-picker
+            id="range-picker"
+            mode="range"
+          ></mnt-date-picker>
+          <div id="range-output" style="margin-top: 16px; padding: 12px; background: #f5f5f5; border-radius: 4px; min-height: 60px;">
+            <strong>Período Selecionado:</strong>
+            <div id="range-dates">Nenhum</div>
+          </div>
+        </div>
+      </div>
+
+      <div style="margin-top: 24px; padding: 16px; background: #fff3cd; border-radius: 4px;">
+        <strong>💡 Dica:</strong> Abra o Console para ver os eventos detalhados!
+      </div>
+    </div>
+
+    <script>
+      // Single mode listener
+      const singlePicker = document.getElementById('single-picker');
+      const singleOutput = document.getElementById('single-date');
+
+      singlePicker.addEventListener('datePickerSelected', (event) => {
+        console.log('Single Date Selected:', event.detail);
+        singleOutput.textContent = event.detail.formattedDate || 'Nenhuma';
+      });
+
+      singlePicker.addEventListener('datePickerCancel', () => {
+        console.log('Single Picker Cancelled');
+      });
+
+      // Range mode listener
+      const rangePicker = document.getElementById('range-picker');
+      const rangeOutput = document.getElementById('range-dates');
+
+      rangePicker.addEventListener('datePickerSelected', (event) => {
+        console.log('Range Selected:', event.detail);
+        if (event.detail.range) {
+          const start = event.detail.range.start ? new Date(event.detail.range.start).toLocaleDateString('pt-BR') : '?';
+          const end = event.detail.range.end ? new Date(event.detail.range.end).toLocaleDateString('pt-BR') : '?';
+          rangeOutput.textContent = start + ' até ' + end;
+        }
+      });
+
+      rangePicker.addEventListener('datePickerCancel', () => {
+        console.log('Range Picker Cancelled');
+      });
+    </script>
+  `;
+};
+
+IntegrationExample.parameters = {
+  controls: { disable: true },
+  docs: {
+    description: {
+      story:
+        '**Exemplo completo de integração** demonstrando:\n\n' +
+        '- Evento `datePickerSelected` para capturar seleções\n' +
+        '- Evento `datePickerCancel` quando usuário cancela\n' +
+        '- Modo single e range funcionando simultaneamente\n' +
+        '- Display em tempo real dos valores selecionados\n\n' +
+        'Todos os eventos são logados no console para debugging.',
+    },
+  },
+};
+
+export const AngularExample: StoryFn = (): HTMLString => {
+  return `
+    <div style="padding: 20px; max-width: 900px; margin: 0 auto;">
+      <h3>Exemplo de Uso no Angular</h3>
+
+      <div style="background: #2d2d2d; color: #f8f8f2; padding: 20px; border-radius: 8px; overflow-x: auto;">
+        <pre style="margin: 0; font-family: 'Monaco', 'Courier New', monospace; font-size: 13px;"><code>&lt;!-- Template --&gt;
+&lt;mnt-date-picker
+  [mode]="'single'"
+  [selectedDate]="selectedDate"
+  (datePickerSelected)="handleDateSelected($event)"
+  (datePickerCancel)="handleCancel()"
+&gt;&lt;/mnt-date-picker&gt;
+
+&lt;!-- Range Mode --&gt;
+&lt;mnt-date-picker
+  [mode]="'range'"
+  [selectedRange]="selectedRange"
+  [minDate]="minDate"
+  [disablePastDates]="true"
+  (datePickerSelected)="handleRangeSelected($event)"
+&gt;&lt;/mnt-date-picker&gt;
+
+// Componente TypeScript
+export class MyComponent {
+  selectedDate: Date | null = null;
+  selectedRange = { start: null, end: null };
+  minDate = new Date();
+
+  handleDateSelected(event: any): void {
+    console.log('Data selecionada:', event.detail);
+    this.selectedDate = event.detail.date;
+  }
+
+  handleRangeSelected(event: any): void {
+    console.log('Período selecionado:', event.detail);
+    this.selectedRange = event.detail.range;
+  }
+
+  handleCancel(): void {
+    console.log('Seleção cancelada');
+  }
+}</code></pre>
+      </div>
+
+      <div style="margin-top: 20px; padding: 16px; background: #e7f3ff; border-left: 4px solid #0066ff; border-radius: 4px;">
+        <strong>✅ Simples assim!</strong>
+        <p style="margin: 8px 0 0 0;">
+          Não precisa de wrappers ou diretivas complexas.
+          Use diretamente com eventos <code>(datePickerSelected)</code> e binding <code>[selectedDate]</code>.
+        </p>
+      </div>
+    </div>
+  `;
+};
+
+AngularExample.parameters = {
+  controls: { disable: true },
+};
+
+// Story: Disable Past Dates
+export const DisablePastDates = DefaultTemplate.bind({});
+DisablePastDates.args = {
+  mode: 'single',
+  locale: 'pt-BR',
+  disablePastDates: true,
+} as Partial<DatePickerBaseProps>;
+DisablePastDates.parameters = {
+  docs: {
+    description: {
+      story:
+        '**Desabilita datas passadas**. ' +
+        'Quando a propriedade `disable-past-dates` está ativa, apenas datas a partir de hoje podem ser selecionadas. ' +
+        'Útil para agendamentos, reservas e qualquer situação onde datas passadas não fazem sentido.\n\n' +
+        '```html\n' +
+        '<mnt-date-picker disable-past-dates></mnt-date-picker>\n' +
+        '```',
+    },
+  },
+};

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -1,0 +1,474 @@
+import { Component, Host, Prop, Event, EventEmitter, h, State, Watch, Element } from '@stencil/core';
+import { AttachInternals } from '@stencil/core/internal';
+import {
+  COMPONENT_PREFIX,
+  // DatePickerBaseProps,
+  DateSelectedEventDetail,
+  DatePickerMode,
+  DateRange,
+  MonthYear,
+} from './date-picker.types';
+
+@Component({
+  tag: 'mnt-date-picker',
+  styleUrl: 'date-picker.scss',
+  shadow: false,
+  formAssociated: true,
+})
+export class DatePicker {
+  @Element() el: HTMLElement;
+  @AttachInternals() internals: ElementInternals;
+
+  // Props
+  @Prop({ mutable: true, reflect: true }) mode?: DatePickerMode = 'single';
+  @Prop({ mutable: true }) selectedDate?: Date | string | null = null;
+  @Prop({ mutable: true }) selectedRange?: DateRange | null = null;
+  @Prop() minDate?: Date | string | null = null;
+  @Prop() maxDate?: Date | string | null = null;
+  @Prop() initialMonth?: Date | string | null = null;
+  @Prop() locale?: string = 'pt-BR';
+  @Prop() disabled?: boolean = false;
+  @Prop() required?: boolean = false;
+  @Prop() placeholder?: string;
+  @Prop() firstDayOfWeek?: number = 0; // 0 = Sunday
+  @Prop() disablePastDates?: boolean = false; // Desabilita datas anteriores ao dia atual
+
+  // State
+  @State() private currentMonth: MonthYear;
+  @State() private internalSelectedDate: Date | null = null;
+  @State() private internalSelectedRange: DateRange = { start: null, end: null };
+  @State() private hoverDate: Date | null = null;
+  // @State() private isOpen: boolean = false;
+
+  // Events
+  @Event({ eventName: 'datePickerSelected' }) datePickerSelected: EventEmitter<DateSelectedEventDetail>;
+  @Event({ eventName: 'datePickerCancel' }) datePickerCancel: EventEmitter<void>;
+  @Event({ eventName: 'datePickerMonthChange' }) datePickerMonthChange: EventEmitter<MonthYear>;
+
+  private today: Date = new Date();
+
+  componentWillLoad() {
+    // Initialize dates
+    this.initializeDates();
+
+    // Initialize current month
+    const initDate = this.getInitialMonthDate();
+    this.currentMonth = {
+      month: initDate.getMonth(),
+      year: initDate.getFullYear(),
+    };
+
+    this.updateFormValue();
+  }
+
+  @Watch('selectedDate')
+  watchSelectedDate(newValue: Date | string | null) {
+    this.internalSelectedDate = this.parseDate(newValue);
+    this.updateFormValue();
+  }
+
+  @Watch('selectedRange')
+  watchSelectedRange(newValue: DateRange | null) {
+    if (newValue) {
+      this.internalSelectedRange = {
+        start: this.parseDate(newValue.start),
+        end: this.parseDate(newValue.end),
+      };
+    }
+    this.updateFormValue();
+  }
+
+  private initializeDates(): void {
+    if (this.mode === 'single') {
+      this.internalSelectedDate = this.parseDate(this.selectedDate);
+    } else {
+      if (this.selectedRange) {
+        this.internalSelectedRange = {
+          start: this.parseDate(this.selectedRange.start),
+          end: this.parseDate(this.selectedRange.end),
+        };
+      }
+    }
+  }
+
+  private getInitialMonthDate(): Date {
+    if (this.initialMonth) {
+      const parsed = this.parseDate(this.initialMonth);
+      if (parsed) return parsed;
+    }
+
+    if (this.mode === 'single' && this.internalSelectedDate) {
+      return this.internalSelectedDate;
+    }
+
+    if (this.mode === 'range' && this.internalSelectedRange.start) {
+      return this.internalSelectedRange.start;
+    }
+
+    return new Date();
+  }
+
+  private parseDate(date: Date | string | null | undefined): Date | null {
+    if (!date) return null;
+    if (date instanceof Date) return date;
+    const parsed = new Date(date);
+    return isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  private updateFormValue(): void {
+    if (this.mode === 'single') {
+      const value = this.internalSelectedDate ? this.internalSelectedDate.toISOString() : null;
+      this.internals.setFormValue(value);
+    } else {
+      const value =
+        this.internalSelectedRange.start && this.internalSelectedRange.end
+          ? JSON.stringify({
+              start: this.internalSelectedRange.start.toISOString(),
+              end: this.internalSelectedRange.end.toISOString(),
+            })
+          : null;
+      this.internals.setFormValue(value);
+    }
+
+    // Update validity
+    if (this.required) {
+      const hasValue = this.mode === 'single' ? this.internalSelectedDate !== null : this.internalSelectedRange.start !== null && this.internalSelectedRange.end !== null;
+
+      if (!hasValue) {
+        this.internals.setValidity({ valueMissing: true }, 'Please select a date.');
+      } else {
+        this.internals.setValidity({});
+      }
+    } else {
+      this.internals.setValidity({});
+    }
+  }
+
+  private handleDateClick = (date: Date): void => {
+    if (this.disabled || !this.isDateSelectable(date)) return;
+
+    if (this.mode === 'single') {
+      this.internalSelectedDate = date;
+      this.selectedDate = date;
+      this.updateFormValue();
+
+      this.datePickerSelected.emit({
+        date: date,
+        formattedDate: this.formatDate(date),
+        mode: 'single',
+      });
+    } else {
+      // Range mode
+      if (!this.internalSelectedRange.start || (this.internalSelectedRange.start && this.internalSelectedRange.end)) {
+        // Start new range
+        this.internalSelectedRange = { start: date, end: null };
+      } else {
+        // Complete range
+        if (date < this.internalSelectedRange.start) {
+          this.internalSelectedRange = { start: date, end: this.internalSelectedRange.start };
+        } else {
+          this.internalSelectedRange = { ...this.internalSelectedRange, end: date };
+        }
+
+        this.selectedRange = this.internalSelectedRange;
+        this.updateFormValue();
+
+        this.datePickerSelected.emit({
+          date: null,
+          range: this.internalSelectedRange,
+          formattedDate: this.formatRange(this.internalSelectedRange.start, this.internalSelectedRange.end),
+          mode: 'range',
+        });
+      }
+    }
+
+    // Emit native events for framework compatibility
+    this.el.dispatchEvent(
+      new CustomEvent('change', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          date: this.mode === 'single' ? this.internalSelectedDate : null,
+          range: this.mode === 'range' ? this.internalSelectedRange : null,
+        },
+      }),
+    );
+  };
+
+  // private handleCancel = (): void => {
+  //   this.datePickerCancel.emit();
+  //   console.log('cancel')
+  //   // this.isOpen = false;
+  // };
+
+  private isDateSelectable(date: Date): boolean {
+    const minDate = this.parseDate(this.minDate);
+    const maxDate = this.parseDate(this.maxDate);
+
+    // Verifica se deve desabilitar datas passadas
+    if (this.disablePastDates) {
+      const todayStart = this.getStartOfDay(new Date());
+      const dateStart = this.getStartOfDay(date);
+      if (dateStart.getTime() < todayStart.getTime()) return false;
+    }
+
+    if (minDate && this.isBefore(date, minDate)) return false;
+    if (maxDate && this.isAfter(date, maxDate)) return false;
+
+    return true;
+  }
+
+  private isSameDay(date1: Date | null, date2: Date | null): boolean {
+    if (!date1 || !date2) return false;
+    return date1.getDate() === date2.getDate() && date1.getMonth() === date2.getMonth() && date1.getFullYear() === date2.getFullYear();
+  }
+
+  private isBefore(date1: Date, date2: Date): boolean {
+    return date1.getTime() < this.getStartOfDay(date2).getTime();
+  }
+
+  private isAfter(date1: Date, date2: Date): boolean {
+    return date1.getTime() > this.getEndOfDay(date2).getTime();
+  }
+
+  private getStartOfDay(date: Date): Date {
+    const d = new Date(date);
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }
+
+  private getEndOfDay(date: Date): Date {
+    const d = new Date(date);
+    d.setHours(23, 59, 59, 999);
+    return d;
+  }
+
+  private formatDate(date: Date | null): string {
+    if (!date) return '';
+    return date.toLocaleDateString(this.locale);
+  }
+
+  private formatRange(start: Date | null, end: Date | null): string {
+    if (!start || !end) return '';
+    return `${this.formatDate(start)} - ${this.formatDate(end)}`;
+  }
+
+  private previousMonth = (): void => {
+    const newMonth = this.currentMonth.month === 0 ? 11 : this.currentMonth.month - 1;
+    const newYear = this.currentMonth.month === 0 ? this.currentMonth.year - 1 : this.currentMonth.year;
+
+    this.currentMonth = { month: newMonth, year: newYear };
+    this.datePickerMonthChange.emit(this.currentMonth);
+  };
+
+  private nextMonth = (): void => {
+    const newMonth = this.currentMonth.month === 11 ? 0 : this.currentMonth.month + 1;
+    const newYear = this.currentMonth.month === 11 ? this.currentMonth.year + 1 : this.currentMonth.year;
+
+    this.currentMonth = { month: newMonth, year: newYear };
+    this.datePickerMonthChange.emit(this.currentMonth);
+  };
+
+  private getDaysInMonth(month: number, year: number): Date[] {
+    const firstDay = new Date(year, month, 1);
+    const lastDay = new Date(year, month + 1, 0);
+    const days: Date[] = [];
+
+    // Add padding days from previous month
+    const firstDayOfWeek = firstDay.getDay();
+    const paddingDays = (firstDayOfWeek - this.firstDayOfWeek + 7) % 7;
+
+    for (let i = paddingDays; i > 0; i--) {
+      const date = new Date(year, month, 1 - i);
+      days.push(date);
+    }
+
+    // Add days of current month
+    for (let day = 1; day <= lastDay.getDate(); day++) {
+      days.push(new Date(year, month, day));
+    }
+
+    // Adiciona apenas os dias necessários para completar a última semana
+    const lastDayOfWeek = lastDay.getDay();
+    const remainingDays = (6 - lastDayOfWeek + this.firstDayOfWeek) % 7;
+
+    for (let i = 1; i <= remainingDays; i++) {
+      days.push(new Date(year, month + 1, i));
+    }
+
+    return days;
+  }
+
+  private getWeekDayNames(): string[] {
+    const baseDate = new Date(2024, 0, this.firstDayOfWeek); // A Sunday
+    const names: string[] = [];
+
+    for (let i = 0; i < 7; i++) {
+      const date = new Date(baseDate);
+      date.setDate(baseDate.getDate() + i);
+      names.push(date.toLocaleDateString(this.locale, { weekday: 'narrow' }));
+    }
+
+    return names;
+  }
+
+  private getMonthName(): string {
+    const date = new Date(this.currentMonth.year, this.currentMonth.month);
+    return date
+      .toLocaleDateString(this.locale, { month: 'long', year: 'numeric' })
+      .replace(/^\w/, (c) => c.toUpperCase())
+      .replace('.', '')
+      .replace(' de ', ' ');
+  }
+
+  private isInRange(date: Date): boolean {
+    if (this.mode !== 'range') return false;
+    const { start, end } = this.internalSelectedRange;
+    if (!start) return false;
+
+    if (end) {
+      return date >= start && date <= end;
+    }
+
+    // Hover effect
+    if (this.hoverDate && this.hoverDate > start) {
+      return date >= start && date <= this.hoverDate;
+    }
+
+    return false;
+  }
+
+  /**
+   * Public method to get the selected date(s)
+   */
+  public getSelectedDate(): Date | DateRange | null {
+    if (this.mode === 'single') {
+      return this.internalSelectedDate;
+    }
+    return this.internalSelectedRange;
+  }
+
+  /**
+   * Public method to set the selected date
+   */
+  public setSelectedDate(date: Date | null): void {
+    if (this.mode === 'single') {
+      this.selectedDate = date;
+    }
+  }
+
+  /**
+   * Public method to set the selected range
+   */
+  public setSelectedRange(range: DateRange): void {
+    if (this.mode === 'range') {
+      this.selectedRange = range;
+    }
+  }
+
+  /**
+   * Public method to clear selection
+   */
+  public clearSelection(): void {
+    if (this.mode === 'single') {
+      this.internalSelectedDate = null;
+      this.selectedDate = null;
+    } else {
+      this.internalSelectedRange = { start: null, end: null };
+      this.selectedRange = null;
+    }
+    this.updateFormValue();
+  }
+
+  render() {
+    const days = this.getDaysInMonth(this.currentMonth.month, this.currentMonth.year);
+    const weekDays = this.getWeekDayNames();
+    const isCurrentMonth = (date: Date) => date.getMonth() === this.currentMonth.month;
+
+    return (
+      <Host class={`${COMPONENT_PREFIX}-container`}>
+        <div class={`${COMPONENT_PREFIX}`}>
+          {/* Header */}
+          <div class={`${COMPONENT_PREFIX}-header`}>
+            <mnt-button-icon
+              variant="plain"
+              color="neutral"
+              icon="caret-left"
+              size="tiny"
+              onClick={() => this.previousMonth()}
+              disabled={this.disabled}
+              aria-label="Previous month"
+            ></mnt-button-icon>
+
+            <div class={`${COMPONENT_PREFIX}-title`}>{this.getMonthName()}</div>
+
+            <mnt-button-icon
+              variant="plain"
+              color="neutral"
+              icon="caret-right"
+              size="tiny"
+              onClick={() => this.nextMonth()}
+              disabled={this.disabled}
+              aria-label="Previous month"
+            ></mnt-button-icon>
+          </div>
+
+          {/* Weekday headers */}
+          <div class={`${COMPONENT_PREFIX}-weekdays`}>
+            {weekDays.map((day) => (
+              <div class={`${COMPONENT_PREFIX}-weekday`}>{day}</div>
+            ))}
+          </div>
+
+          {/* Calendar grid */}
+          <div class={`${COMPONENT_PREFIX}-days`}>
+            {days.map((date) => {
+              const isRangeStart = this.mode === 'range' && this.isSameDay(date, this.internalSelectedRange.start);
+              const isRangeEnd = this.mode === 'range' && this.isSameDay(date, this.internalSelectedRange.end);
+              const isSelected = this.mode === 'single' ? this.isSameDay(date, this.internalSelectedDate) : isRangeStart || isRangeEnd;
+
+              const isInRange = this.isInRange(date);
+              const isToday = this.isSameDay(date, this.today);
+              const isSelectable = this.isDateSelectable(date);
+              const isOtherMonth = !isCurrentMonth(date);
+
+              return (
+                <button
+                  type="button"
+                  class={{
+                    [`${COMPONENT_PREFIX}-day`]: true,
+                    [`${COMPONENT_PREFIX}-day--selected`]: isSelected,
+                    [`${COMPONENT_PREFIX}-day--range-start`]: isRangeStart,
+                    [`${COMPONENT_PREFIX}-day--range-end`]: isRangeEnd,
+                    [`${COMPONENT_PREFIX}-day--in-range`]: isInRange,
+                    [`${COMPONENT_PREFIX}-day--today`]: isToday,
+                    [`${COMPONENT_PREFIX}-day--disabled`]: !isSelectable,
+                    [`${COMPONENT_PREFIX}-day--other-month`]: isOtherMonth,
+                  }}
+                  onClick={() => this.handleDateClick(date)}
+                  onMouseEnter={() => (this.hoverDate = date)}
+                  onMouseLeave={() => (this.hoverDate = null)}
+                  disabled={!isSelectable || this.disabled}
+                  aria-label={this.formatDate(date)}
+                >
+                  {date.getDate()}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Footer with Cancel button */}
+          {/* <div class={`${COMPONENT_PREFIX}-footer`}>
+            <button
+              type="button"
+              class={`${COMPONENT_PREFIX}-cancel-button`}
+              onClick={this.handleCancel}
+            >
+              Cancelar
+            </button>
+          </div> */}
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/components/date-picker/date-picker.types.ts
+++ b/src/components/date-picker/date-picker.types.ts
@@ -1,0 +1,84 @@
+import { getLibPrefix } from 'src/utils/utils';
+
+export const COMPONENT_PREFIX = getLibPrefix() + 'date-picker';
+
+export type DatePickerMode = 'single' | 'range';
+
+export interface DateRange {
+  start: Date | null;
+  end: Date | null;
+}
+
+export interface DatePickerBaseProps {
+  /**
+   * Mode of the date picker: 'single' for single date selection, 'range' for date range selection
+   */
+  mode?: DatePickerMode;
+
+  /**
+   * Selected date (for single mode)
+   */
+  selectedDate?: Date | string | null;
+
+  /**
+   * Selected date range (for range mode)
+   */
+  selectedRange?: DateRange | null;
+
+  /**
+   * Minimum selectable date
+   */
+  minDate?: Date | string | null;
+
+  /**
+   * Maximum selectable date
+   */
+  maxDate?: Date | string | null;
+
+  /**
+   * Initial month to display (defaults to selected date or current month)
+   */
+  initialMonth?: Date | string | null;
+
+  /**
+   * Locale for date formatting (e.g., 'pt-BR', 'en-US')
+   */
+  locale?: string;
+
+  /**
+   * Whether the date picker is disabled
+   */
+  disabled?: boolean;
+
+  /**
+   * Whether the date picker is required for form validation
+   */
+  required?: boolean;
+
+  /**
+   * Custom placeholder text
+   */
+  placeholder?: string;
+
+  /**
+   * First day of the week (0 = Sunday, 1 = Monday, etc.)
+   */
+  firstDayOfWeek?: number;
+
+  /**
+   * Disable selection of dates before today
+   */
+  disablePastDates?: boolean;
+}
+
+export interface DateSelectedEventDetail {
+  date: Date | null;
+  range?: DateRange | null;
+  formattedDate?: string;
+  mode: DatePickerMode;
+}
+
+export interface MonthYear {
+  month: number; // 0-11
+  year: number;
+}

--- a/src/components/date-picker/styles/__base.scss
+++ b/src/components/date-picker/styles/__base.scss
@@ -1,0 +1,198 @@
+@use "sass:map";
+@use "../../../shared/theme/core/theme" as theme;
+@use "../../../shared/theme/tokens/_sizing" as sizing;
+
+$component-prefix: theme.get-prefix('date-picker');
+$border-radius: 6px;
+
+$focus-outline-width: 2px;
+
+$range-start-bg-color: #83CEF6;
+$range-start-text-color: #0D547F;
+$range-bg-color: #E1F1FD;
+$range-text-color: #0D547F;
+
+// Sizes
+
+@mixin set-calendar-grid() {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  align-items: center;
+  text-align: center;
+  gap: $focus-outline-width; // Grants a better visual separation between days on keyboard navigation
+}
+
+#{$component-prefix} {
+  display: block;
+  padding: 16px;
+  max-width: 320px;
+  width: fit-content;
+
+  background: #FFFFFF;
+  border-radius: 12px;
+  box-sizing: border-box;
+  box-shadow:
+    0 0 4px 0 rgba(0, 0, 0, 0.03),
+    0 2px 8px 0 rgba(0, 0, 0, 0.03),
+    0 4px 12px 0 rgba(0, 0, 0, 0.03),
+    0 6px 16px 0 rgba(0, 0, 0, 0.03);
+
+  .#{$component-prefix}-header {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+
+    .#{$component-prefix}-title {
+      font-size: 14px;
+      line-height: 20px;
+      text-wrap: nowrap;
+
+      color: #242628;
+      font-weight: 500;
+    }
+  }
+
+  .#{$component-prefix}-weekdays,
+  .#{$component-prefix}-days button {
+    font-size: 14px;
+    line-height: 20px;
+    padding: 4px;
+  }
+
+  .#{$component-prefix}-weekdays {
+    @include set-calendar-grid();
+    margin-bottom: 12px;
+    font-weight: 400;
+    color: #5F676C;
+  }
+
+  .#{$component-prefix}-days {
+    @include set-calendar-grid();
+
+    button.#{$component-prefix}-day {
+      appearance: none;
+      border: none;
+      color: #4B5053;
+      font-weight: 500;
+      background-color: #FFF;
+      border-radius: $border-radius;
+      height: 32px;
+      width: 32px;
+
+      &:hover {
+        cursor: pointer;
+        background-color: #F5F5F5;
+      }
+
+      &:focus-visible {
+        outline: $focus-outline-width solid #0D547F;
+      }
+
+      &,
+      &:hover,
+      &:disabled,
+      &:focus,
+      &:focus-visible {
+        transition: all ease-in-out .2s;
+      }
+
+      // Modifiers
+
+      &--today {
+        position: relative;
+        color: inherit;
+
+        &::after {
+          content: "";
+          display: block;
+          position: absolute;
+          height: 4px;
+          width: 4px;
+          margin: auto;
+          top: auto;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          background-color: $range-start-bg-color;
+          border-radius: $border-radius;
+          background-color: $range-start-bg-color;
+        }
+      }
+
+      &--selected {
+        background-color: $range-start-bg-color;
+        color: $range-start-text-color;
+
+        &:hover {
+          background-color: #BDE3FA;
+        }
+      }
+
+      &--disabled,
+      &:disabled {
+        opacity: 0.25;
+        background-color: transparent;
+        text-decoration: line-through;
+
+        &:hover {
+          cursor: not-allowed;
+        }
+      }
+
+      &--other-month {
+        background-color: transparent;
+        opacity: 0.5;
+      }
+    }
+  }
+
+  // RANGE STYLE
+
+  &[mode="range"] {
+    // Dias dentro do range (entre início e fim)
+    button.#{$component-prefix}-day--in-range {
+      background-color: $range-bg-color;
+      color: $range-text-color;
+      border-radius: 0;
+
+      &:hover {
+        cursor: pointer;
+        // background-color: $range-color-hover;
+      }
+    }
+
+    button.#{$component-prefix}-day--range-start,
+    button.#{$component-prefix}-day--range-end {
+      background-color: $range-start-bg-color;
+      color: $range-start-text-color;
+      font-weight: 500;
+    }
+
+    // Data de INÍCIO do range
+    button.#{$component-prefix}-day--range-start {
+      border-top-left-radius: $border-radius;
+      border-bottom-left-radius: $border-radius;
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+
+    // Data de FIM do range
+    button.#{$component-prefix}-day--range-end {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+      border-top-right-radius: $border-radius;
+      border-bottom-right-radius: $border-radius;
+    }
+
+    // Quando início e fim são a mesma data (range de 1 dia)
+    button.#{$component-prefix}-day--range-start.#{$component-prefix}-day--range-end {
+      border-radius: $border-radius;
+
+      &::before {
+        display: none;
+      }
+    }
+  }
+}

--- a/src/components/date-picker/styles/_variant-default.scss
+++ b/src/components/date-picker/styles/_variant-default.scss
@@ -1,0 +1,16 @@
+@use "sass:map";
+
+// @use "../../../shared/theme/tokens/feedbacks/index.scss" as feedback-tokens;
+@use "../../../shared/theme/core/theme" as theme;
+
+$component-prefix: theme.get-prefix('date-picker');
+
+///
+/// Date Picker Default Theme
+///
+
+@mixin set-date-picker-styles() {
+  // TODO: Implement DEFAULT styles
+
+  // TODO: Implement RANGE styles
+}

--- a/src/components/date-picker/styles/index.scss
+++ b/src/components/date-picker/styles/index.scss
@@ -1,0 +1,15 @@
+/**
+* This file is a barrel file for the styles of the <mnt-date-picker> component.
+*
+* WARNING: Do not add CSS rules directly to the file src/components/date-picker/date-picker.scss.
+*
+* Use the variant files (_variant-default.scss) to define specific styles.
+**/
+
+@use "sass:map";
+
+@forward "./__base"; // Base styles for the date picker component
+
+@use "./_variant-default" as date-picker-default;
+
+@include date-picker-default.set-date-picker-styles();


### PR DESCRIPTION
### 🚀 Adicionado

- **DatePicker**: Novo componente de seleção de datas
  - Modo single: Seleção de data única
  - Modo range: Seleção de intervalo/período entre duas datas
  - Propriedade `disablePastDates`: Desabilita seleção de datas anteriores ao dia atual
  - Integração nativa com formulários HTML via `formAssociated`
  - Validação integrada com suporte a `required` e custom validity
  - Eventos customizados: `date-selected`, `cancel`, `month-change`
  - Internacionalização: Suporte a diferentes locales (pt-BR, en-US, etc.)
  - Acessibilidade: ARIA attributes e navegação via teclado
  - Configurações: `minDate`, `maxDate`, `firstDayOfWeek`, `initialMonth`
  - Distinção visual entre início e fim do range (modo range)
  - Calendário dinâmico: Exibe apenas semanas do mês atual/necessárias
  - Documentação completa e exemplos no Storybook
  - Exemplos práticos no `index.html`