### PR TITLE
ci: remover deploy do GitHub Pages do workflow da main

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,4 +1,4 @@
-name: Deploy Jekyll and Storybook to GitHub Pages
+name: Publish to GitHub Packages
 
 on:
   push:
@@ -8,13 +8,7 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
   packages: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
 
 jobs:
   build:
@@ -48,33 +42,7 @@ jobs:
       - name: Construir o pacote
         run: npm run build
 
-      - name: Build do Storybook
-        run: npm run build-storybook
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v6
-
-      - name: Build com Jekyll
-        uses: actions/jekyll-build-pages@v1
-        with:
-          source: ./
-          destination: ./_site
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
-
       - name: Publicar no GitHub Packages
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy para GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Contexto

Complementa #140: o GitHub Pages passa a ser publicado a partir da branch `v2`, então o workflow da `main` não deve mais disputar o deploy do Pages.

## O que muda

`.github/workflows/deploy.yaml` (renomeado para *Publish to GitHub Packages*):

- removidas as etapas `Build do Storybook`, `Setup Pages`, `Build com Jekyll` e `Upload artifact`, e o job `deploy` inteiro
- removidas as permissões `pages: write` / `id-token: write` e o bloco `concurrency: pages`
- mantido o fluxo de build + `npm publish` no GitHub Packages

Observação: a etapa Jekyll não fazia falta — o repositório não tem `_config.yml`, `index.html` nem layouts; o conteúdo real do site sempre foi o Storybook.

## Ordem de merge

⚠️ Mergear **depois** de #140, para o site não ficar sem publicação em nenhum momento.

## Verificação

Após o merge, um push na `main` deve rodar apenas o job de publish no GitHub Packages (sem deploy de Pages), e `https://yooga-tecnologia.github.io/mantra/` deve continuar exibindo o Storybook da v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)