### PR TITLE
fix(storybook): renderizar componentes nas docs do GitHub Pages (v2)

### DIFF
--- a/.storybook/_fonts.scss
+++ b/.storybook/_fonts.scss
@@ -1,11 +1,13 @@
 /* Poppins Font Faces for Storybook */
+// Relative paths are resolved by Vite from the source file location and emitted
+// as hashed assets — this ensures correct URLs regardless of the deployment subpath.
 
 @font-face {
   font-family: 'Poppins';
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/fonts/Poppins-Regular.woff2') format('woff2');
+  src: url('../dist-custom-elements/fonts/Poppins-Regular.woff2') format('woff2');
 }
 
 @font-face {
@@ -13,7 +15,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url('/fonts/Poppins-Medium.woff2') format('woff2');
+  src: url('../dist-custom-elements/fonts/Poppins-Medium.woff2') format('woff2');
 }
 
 @font-face {
@@ -21,7 +23,7 @@
   font-style: normal;
   font-weight: 600;
   font-display: swap;
-  src: url('/fonts/Poppins-SemiBold.woff2') format('woff2');
+  src: url('../dist-custom-elements/fonts/Poppins-SemiBold.woff2') format('woff2');
 }
 
 /* Aplicar Poppins como fonte padrão */

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,10 +1,14 @@
-import { defineCustomElements } from '../loader';
+// Each mnt-*.js in dist/components calls customElements.define() on import
+// (auto-define-custom-elements). Vite's eager glob expands to individual
+// static imports at build time, preserving side effects without lazy loading.
+import.meta.glob('../dist/components/mnt-*.js', { eager: true });
+
 import customElements from '../custom-elements.json';
 
-import './_fonts.scss';
+// _styles.scss imports _typography.scss which generates @font-face with absolute /fonts/ paths.
+// _fonts.scss must come AFTER so its correctly-resolved relative paths win the CSS cascade.
 import './_styles.scss';
-
-defineCustomElements();
+import './_fonts.scss';
 
 // Configurar custom elements manifest para Storybook v10
 if (customElements) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yooga-tecnologia/mantra",
-  "version": "2.11.7",
+  "version": "2.11.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@yooga-tecnologia/mantra",
-      "version": "2.11.7",
+      "version": "2.11.8",
       "license": "MIT",
       "devDependencies": {
         "@stencil/core": "^4.25.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:e2e": "stencil test --spec --e2e",
     "test.watch:e2e": "stencil test --spec --e2e --watchAll",
     "generate": "stencil generate",
+    "prestorybook": "[ -d dist/components ] || npm run build",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "npm run build && storybook build",
     "cache-clear": "rm -rf ./node_modules ./dist/ ./.stencil/ ./storybook-static/ ./www ./loader/",


### PR DESCRIPTION
## Problema

Após a migração do deploy do Pages para a branch `v2` (#140/#142), o Storybook publicado em https://yooga-tecnologia.github.io/mantra/ exibe previews vazios em **todas** as páginas de docs, com o erro no console:

```
Uncaught (in promise) Error: Constructor for "mnt-badge-icon#undefined" was not found
```

## Causa raiz

O `.storybook/preview.js` da v2 registra os componentes pelo **lazy loader** do Stencil (`import { defineCustomElements } from '../loader'`). O `loadModule` do lazy loader usa dynamic import computado (``import(`./${bundleId}.entry.js`)``), que o Vite não consegue analisar estaticamente:

1. Nenhum chunk `*.entry.js` é emitido no `storybook-static/` (e o `staticDirs` só copia fontes);
2. Em runtime o import resolve para `/mantra/assets/mnt-badge-icon.entry.js` → **404** (verificado no site ao vivo);
3. O construtor fica `undefined` e o Stencil lança o erro acima para todas as tags → previews vazios.

O mesmo bug já foi corrigido na `main` em 252154f/6e7b248 (PRs #114/#115), mas o fix nunca foi portado para a `v2` — que agora é quem publica o Pages.

## Correção (backport da main)

- **`.storybook/preview.js`**: substitui o lazy loader por `import.meta.glob('../dist/components/mnt-*.js', { eager: true })` — o output `dist-custom-elements` já usa `auto-define-custom-elements` (nenhuma mudança no `stencil.config.ts`). Também reordena `_styles.scss` antes de `_fonts.scss` para o cascade das fontes.
- **`.storybook/_fonts.scss`**: paths relativos para as fontes Poppins (o Vite emite como assets com hash, corretos em qualquer subpath).
- **`package.json`**: adiciona o guard `prestorybook` da main (dev local sem `dist/`).
- **`package-lock.json`**: sincroniza a versão 2.11.8 do bump anterior (a lock ainda apontava 2.11.7).

Mantido `config.base = '/mantra/'` — na v2 o `storybook-static` é copiado para a raiz do site, diferente da main (`/mantra/storybook-static/`).

## Verificação

Build local (`npm run build-storybook`, Node 22) servido sob o subpath `/mantra/` e validado em Chrome headless na página `components-badge-badgeicon--docs`:

- ✅ 76/76 `mnt-badge-icon` renderizando conteúdo (incl. `mnt-icon` aninhado)
- ✅ `customElements.get('mnt-badge-icon')` definido; **zero** erros `Constructor ... was not found`
- ✅ Fontes Poppins carregando (assets com hash)
- ✅ Runtime lazy ausente do bundle (`bootstrapLazy`/`*.entry.js` = 0 ocorrências)
- ✅ Mesma validação no modo dev (`npm run storybook`)

Após o merge, o workflow `Publish v2 and Deploy GitHub Pages` publica o site; conferir https://yooga-tecnologia.github.io/mantra/?path=/docs/components-badge-badgeicon--docs. O job `publish` não republica o pacote (guard de versão já publicada, 2.11.8).

## Nota (fora do escopo)

`src/components/date-picker/readme.md` nunca foi commitado — a descrição rica do DatePicker existente no `custom-elements.json` commitado é apagada a cada `stencil build` (inclusive no CI, ou seja, as docs publicadas do DatePicker já ficam sem descrição). Vale commitar esse readme num PR separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)